### PR TITLE
feat: add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY gemini_web2api.py .
+COPY config.example.json ./config.json
+
+EXPOSE 8081
+
+CMD ["python", "gemini_web2api.py"]


### PR DESCRIPTION
## Summary
Minimal Dockerfile for one-command deployment.

- Based on `python:3.12-slim`
- No `pip install` needed (stdlib only)
- Exposes port 8081

```bash
docker build -t gemini-web2api .
docker run -p 8081:8081 gemini-web2api
```

### Changes
- New file: `Dockerfile` (10 lines)