### PR TITLE
feat: add Google native API support for Gemini CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Convert Google Gemini's web interface into an OpenAI-compatible API. Zero authen
 - **Cross-Platform**: Pure Python, no dependencies beyond stdlib
 - **Streaming**: SSE streaming support
 - **Codex CLI**: Responses API (`/v1/responses`) for OpenAI Codex integration
+- **Gemini CLI**: Google native API (`/v1beta/models`) for Gemini CLI compatibility
 
 ## Quick Start
 
@@ -57,6 +58,19 @@ resp = client.chat.completions.create(
 )
 print(resp.choices[0].message.content)
 ```
+
+### Gemini CLI
+
+```bash
+export GEMINI_API_KEY=none
+export GOOGLE_GEMINI_BASE_URL=http://localhost:8081
+gemini
+```
+
+Supports Google native API endpoints:
+- `GET /v1beta/models` — list models
+- `POST /v1beta/models/{model}:generateContent` — non-streaming
+- `POST /v1beta/models/{model}:streamGenerateContent` — streaming (SSE)
 
 ## Available Models
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -19,6 +19,7 @@
 - **跨平台**: 纯 Python, 无外部依赖
 - **流式输出**: SSE Streaming 支持
 - **Codex CLI**: Responses API (`/v1/responses`) 兼容 OpenAI Codex
+- **Gemini CLI**: Google 原生 API (`/v1beta/models`) 兼容 Gemini CLI
 
 ## 快速开始
 
@@ -57,6 +58,19 @@ resp = client.chat.completions.create(
 )
 print(resp.choices[0].message.content)
 ```
+
+### Gemini CLI
+
+```bash
+export GEMINI_API_KEY=none
+export GOOGLE_GEMINI_BASE_URL=http://localhost:8081
+gemini
+```
+
+支持 Google 原生 API 端点:
+- `GET /v1beta/models` — 模型列表
+- `POST /v1beta/models/{model}:generateContent` — 非流式生成
+- `POST /v1beta/models/{model}:streamGenerateContent` — 流式生成 (SSE)
 
 ## 可用模型
 

--- a/gemini_web2api.py
+++ b/gemini_web2api.py
@@ -322,6 +322,8 @@ class GeminiHandler(BaseHTTPRequestHandler):
                      "owned_by": "google", "description": c["desc"]}
                     for n, c in MODELS.items()
                 ]})
+            elif self.path.startswith("/v1beta/models"):
+                self._handle_google_models_list()
             elif self.path == "/":
                 self.send_json({"status": "ok", "version": __version__,
                                 "models": list(MODELS.keys())})
@@ -340,6 +342,10 @@ class GeminiHandler(BaseHTTPRequestHandler):
                 self.handle_chat(body)
             elif self.path == "/v1/responses":
                 self.handle_responses(body)
+            elif ":generateContent" in self.path:
+                self._handle_google_generate(body, stream=False)
+            elif ":streamGenerateContent" in self.path:
+                self._handle_google_generate(body, stream=True)
             else:
                 self.send_json({"error": "not found"}, 404)
         except (BrokenPipeError, ConnectionResetError):
@@ -513,6 +519,102 @@ class GeminiHandler(BaseHTTPRequestHandler):
             self.send_json({"id": rid, "object": "response", "created_at": int(time.time()), "status": "completed",
                             "model": model_name, "output": output,
                             "usage": {"input_tokens": len(prompt)//4, "output_tokens": len(text)//4, "total_tokens": (len(prompt)+len(text))//4}})
+
+
+    # ─── Google Native API (Gemini CLI compatible) ────────────────────────────
+
+    def _parse_google_model_from_path(self):
+        """Extract model name from /v1beta/models/{model}:method path."""
+        m = re.match(r'/v1beta/models/([^:?]+)', self.path)
+        if m:
+            return m.group(1)
+        return None
+
+    def _handle_google_models_list(self):
+        """GET /v1beta/models — Google AI format model list."""
+        models = []
+        for name, cfg in MODELS.items():
+            models.append({
+                "name": f"models/{name}",
+                "displayName": name,
+                "description": cfg["desc"],
+                "supportedGenerationMethods": ["generateContent", "streamGenerateContent"],
+            })
+        self.send_json({"models": models})
+
+    def _google_contents_to_prompt(self, req: dict) -> str:
+        """Convert Google API contents format to prompt string."""
+        parts = []
+        sys_inst = req.get("systemInstruction")
+        if sys_inst:
+            sys_parts = sys_inst.get("parts", [])
+            sys_text = " ".join(p.get("text", "") for p in sys_parts if p.get("text"))
+            if sys_text:
+                parts.append(f"[System instruction]: {sys_text}")
+
+        for content in req.get("contents", []):
+            role = content.get("role", "user")
+            text_parts = []
+            for p in content.get("parts", []):
+                if p.get("text"):
+                    text_parts.append(p["text"])
+            text = " ".join(text_parts)
+            if role == "model":
+                parts.append(f"[Assistant]: {text}")
+            else:
+                parts.append(text)
+        return "\n\n".join(p for p in parts if p)
+
+    def _handle_google_generate(self, body: bytes, stream: bool):
+        """Handle Google native generateContent / streamGenerateContent."""
+        req = json.loads(body)
+        model_name = self._parse_google_model_from_path()
+        if not model_name:
+            self.send_json({"error": {"message": "model not specified in path"}}, 400)
+            return
+
+        model_name, model_id, think_mode, err = self._resolve_model(model_name)
+        if err:
+            self.send_json({"error": {"message": err}}, 400)
+            return
+
+        prompt = self._google_contents_to_prompt(req)
+        if not prompt.strip():
+            self.send_json({"error": {"message": "empty content"}}, 400)
+            return
+
+        try:
+            text, _ = self._call_gemini(prompt, model_id, think_mode, None)
+        except Exception as e:
+            self.send_json({"error": {"message": f"upstream error: {e}"}}, 502)
+            return
+
+        candidate = {
+            "content": {"parts": [{"text": text or ""}], "role": "model"},
+            "finishReason": "STOP",
+            "index": 0,
+        }
+        usage = {
+            "promptTokenCount": len(prompt) // 4,
+            "candidatesTokenCount": len(text) // 4,
+            "totalTokenCount": (len(prompt) + len(text)) // 4,
+        }
+        response_obj = {
+            "candidates": [candidate],
+            "usageMetadata": usage,
+            "modelVersion": model_name,
+        }
+
+        if stream:
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Cache-Control", "no-cache")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(f"data: {json.dumps(response_obj)}\n\n".encode())
+            self.wfile.flush()
+        else:
+            self.send_json(response_obj)
 
 
 # ─── Main ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add Google native API endpoints (`/v1beta/models`) for Gemini CLI compatibility
- Support `generateContent` (non-streaming) and `streamGenerateContent` (SSE streaming)
- Gemini CLI can connect via `GOOGLE_GEMINI_BASE_URL` environment variable
- Update README.md and README_CN.md with Gemini CLI usage instructions

## Usage

```bash
export GEMINI_API_KEY=none
export GOOGLE_GEMINI_BASE_URL=http://localhost:8081
gemini
```

## Endpoints Added

| Method | Path | Description |
|--------|------|-------------|
| GET | `/v1beta/models` | List available models (Google format) |
| POST | `/v1beta/models/{model}:generateContent` | Non-streaming generation |
| POST | `/v1beta/models/{model}:streamGenerateContent` | Streaming generation (SSE) |

## Test plan

- [x] `GET /v1beta/models` returns correct model list
- [x] `POST /v1beta/models/gemini-3.5-flash:generateContent` returns valid response
- [x] `POST /v1beta/models/gemini-3.5-flash:streamGenerateContent` returns SSE stream
- [x] Gemini CLI v0.43.0 connects and works end-to-end
- [x] Existing OpenAI-compatible endpoints unaffected