### PR TITLE
feat(server): 添加 API 密钥认证和 Docker 部署支持

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,9 @@
-__pycache__/
+.git
+.idea
+.venv
+__pycache__
 *.pyc
 config.json
 cookie.txt
 cookie.json
 .env
-.idea

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,39 @@
+name: Docker
+
+on:
+  push:
+    branches: ["main"]
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+COPY gemini_web2api.py config.example.json ./
+EXPOSE 8081
+
+CMD ["python", "gemini_web2api.py", "--config", "/app/config.json"]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Convert Google Gemini's web interface into an OpenAI-compatible API. Zero authen
 
 ## Features
 
-- **Zero Auth**: No API key, no Google account needed (anonymous access)
+- **Optional API Keys**: no auth when `api_keys` is empty, OpenAI-style Bearer auth when configured
 - **OpenAI Compatible**: Drop-in replacement for `/v1/chat/completions` and `/v1/models`
 - **Tool Calling**: Full function calling support (OpenAI format)
 - **Multiple Models**: Flash, Flash Thinking (20k+ char output), Pro, Auto, Lite
@@ -35,7 +35,7 @@ Server starts at `http://localhost:8081/v1`.
 | Field | Value |
 |-------|-------|
 | Base URL | `http://localhost:8081/v1` |
-| API Key | `none` (or anything) |
+| API Key | any `api_keys` value from `config.json`; anything if not configured |
 | Model | `gemini-3.5-flash-thinking` |
 
 ### curl
@@ -43,6 +43,7 @@ Server starts at `http://localhost:8081/v1`.
 ```bash
 curl http://localhost:8081/v1/chat/completions \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-your-key" \
   -d '{"model":"gemini-3.5-flash","messages":[{"role":"user","content":"Hello!"}]}'
 ```
 
@@ -50,7 +51,7 @@ curl http://localhost:8081/v1/chat/completions \
 
 ```python
 from openai import OpenAI
-client = OpenAI(base_url="http://localhost:8081/v1", api_key="none")
+client = OpenAI(base_url="http://localhost:8081/v1", api_key="sk-your-key")
 resp = client.chat.completions.create(
     model="gemini-3.5-flash-thinking",
     messages=[{"role": "user", "content": "Explain quantum computing"}]
@@ -118,11 +119,37 @@ Create `config.json` in the same directory:
   "retry_attempts": 3,
   "retry_delay_sec": 2,
   "request_timeout_sec": 180,
+  "api_keys": ["sk-your-key"],
   "cookie_file": null,
   "proxy": null,
   "log_requests": true
 }
 ```
+
+When `api_keys` is `[]`, authentication is disabled. When one or more keys are set, `/v1/*` endpoints require `Authorization: Bearer <key>` or `x-api-key: <key>`.
+
+## Docker
+
+```bash
+cp config.example.json config.json
+docker build -t gemini-web2api .
+docker run -d --name gemini-web2api -p 8081:8081 -v ./config.json:/app/config.json gemini-web2api
+```
+
+Or use Docker Compose:
+
+```bash
+cp config.example.json config.json
+docker compose up -d
+```
+
+To mount a cookie file:
+
+```bash
+docker run -d --name gemini-web2api -p 8081:8081 -v ./config.json:/app/config.json -v ./cookie.txt:/app/cookie.txt gemini-web2api
+```
+
+Set `"cookie_file": "/app/cookie.txt"` in `config.json`.
 
 ## Proxy
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -10,7 +10,7 @@
 
 ## 特性
 
-- **零认证**: 不需要 API Key, 不需要 Google 账号 (匿名访问)
+- **可选密钥**: `api_keys` 为空时免密, 填入密钥后按 OpenAI Bearer Key 校验
 - **OpenAI 兼容**: 直接替换 `/v1/chat/completions` 和 `/v1/models`
 - **工具调用**: 完整的 Function Calling 支持 (OpenAI 格式)
 - **多模型**: Flash, Flash Thinking (2万字+输出), Pro, Auto, Lite
@@ -35,7 +35,7 @@ python gemini_web2api.py
 | 字段 | 值 |
 |------|-----|
 | Base URL | `http://localhost:8081/v1` |
-| API Key | `none` (随便填) |
+| API Key | `config.json` 中的任意 `api_keys`；未配置时随便填 |
 | Model | `gemini-3.5-flash-thinking` |
 
 ### curl
@@ -43,6 +43,7 @@ python gemini_web2api.py
 ```bash
 curl http://localhost:8081/v1/chat/completions \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-your-key" \
   -d '{"model":"gemini-3.5-flash","messages":[{"role":"user","content":"你好!"}]}'
 ```
 
@@ -50,7 +51,7 @@ curl http://localhost:8081/v1/chat/completions \
 
 ```python
 from openai import OpenAI
-client = OpenAI(base_url="http://localhost:8081/v1", api_key="none")
+client = OpenAI(base_url="http://localhost:8081/v1", api_key="sk-your-key")
 resp = client.chat.completions.create(
     model="gemini-3.5-flash-thinking",
     messages=[{"role": "user", "content": "解释量子计算"}]
@@ -118,11 +119,37 @@ SID=你的SID值; HSID=你的HSID值; SSID=你的SSID值; APISID=你的APISID值
   "retry_attempts": 3,
   "retry_delay_sec": 2,
   "request_timeout_sec": 180,
+  "api_keys": ["sk-your-key"],
   "cookie_file": null,
   "proxy": null,
   "log_requests": true
 }
 ```
+
+`api_keys` 为空数组 `[]` 时不校验密钥；填入一个或多个密钥后, `/v1/*` 接口需要 `Authorization: Bearer <key>` 或 `x-api-key: <key>`.
+
+## Docker 部署
+
+```bash
+cp config.example.json config.json
+docker build -t gemini-web2api .
+docker run -d --name gemini-web2api -p 8081:8081 -v ./config.json:/app/config.json gemini-web2api
+```
+
+或使用 Docker Compose:
+
+```bash
+cp config.example.json config.json
+docker compose up -d
+```
+
+如需挂载 Cookie 文件:
+
+```bash
+docker run -d --name gemini-web2api -p 8081:8081 -v ./config.json:/app/config.json -v ./cookie.txt:/app/cookie.txt gemini-web2api
+```
+
+此时 `config.json` 中设置 `"cookie_file": "/app/cookie.txt"`.
 
 ## 代理配置
 

--- a/config.example.json
+++ b/config.example.json
@@ -5,6 +5,9 @@
   "retry_delay_sec": 2,
   "request_timeout_sec": 180,
   "default_model": "gemini-3.5-flash",
+  "api_keys": [
+    "sk-gemini"
+  ],
   "cookie_file": null,
   "proxy": null,
   "log_requests": true

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,9 @@
+services:
+  gemini-web2api:
+    build: .
+    container_name: gemini-web2api
+    ports:
+      - "8081:8081"
+    volumes:
+      - ./config.json:/app/config.json
+    restart: unless-stopped

--- a/gemini_web2api.py
+++ b/gemini_web2api.py
@@ -10,7 +10,7 @@ Usage:
 
 Client configuration (Cherry Studio, ChatBox, etc.):
     Base URL: http://localhost:8081/v1
-    API Key: (anything or empty)
+    API Key: config.api_keys item, or anything if api_keys is empty
 """
 import json
 import urllib.request
@@ -38,6 +38,7 @@ DEFAULT_CONFIG = {
     "request_timeout_sec": 180,
     "gemini_bl": "boq_assistant-bard-web-server_20260525.09_p0",
     "default_model": "gemini-3.5-flash",
+    "api_keys": [],
     "log_requests": True,
     "cookie_file": None,
     "proxy": None,
@@ -307,6 +308,20 @@ class GeminiHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
+    def _authorized(self):
+        keys = CONFIG.get("api_keys") or []
+        if not keys:
+            return True
+        auth = self.headers.get("Authorization", "")
+        key = auth[7:] if auth.startswith("Bearer ") else self.headers.get("x-api-key", "")
+        return key in keys
+
+    def _require_auth(self):
+        if self._authorized():
+            return True
+        self.send_json({"error": {"message": "invalid api key"}}, 401)
+        return False
+
     def do_OPTIONS(self):
         self.send_response(204)
         self.send_header("Access-Control-Allow-Origin", "*")
@@ -316,6 +331,8 @@ class GeminiHandler(BaseHTTPRequestHandler):
 
     def do_GET(self):
         try:
+            if self.path.startswith("/v1/") and not self._require_auth():
+                return
             if self.path == "/v1/models":
                 self.send_json({"object": "list", "data": [
                     {"id": n, "object": "model", "created": 1700000000,
@@ -334,6 +351,8 @@ class GeminiHandler(BaseHTTPRequestHandler):
 
     def do_POST(self):
         try:
+            if self.path.startswith("/v1/") and not self._require_auth():
+                return
             length = int(self.headers.get("Content-Length", 0))
             body = self.rfile.read(length) if length else b""
             if self.path == "/v1/chat/completions":


### PR DESCRIPTION
- 在配置文件中新增 api_keys 字段用于认证控制
- 实现 Bearer Token 和 x-api-key 两种认证方式
- 当 api_keys 为空数组时不启用认证，保持原有行为
- 更新 README 文档说明新的认证配置方式
- 添加 Dockerfile 和 docker-compose 配置文件
- 集成 GitHub Actions 实现 Docker 镜像自动构建推送
- 新增 .dockerignore 文件优化镜像构建