### PR TITLE
fix: install httpx in Docker to enable true SSE streaming

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.12-slim
 
 WORKDIR /app
 COPY gemini_web2api.py config.example.json ./
+RUN pip install --no-cache-dir httpx
 EXPOSE 8081
 
 CMD ["python", "gemini_web2api.py", "--config", "/app/config.json"]


### PR DESCRIPTION
## Problem

Docker deployments silently lose streaming support. The `Dockerfile` only copies `gemini_web2api.py` without installing dependencies, so `httpx` is unavailable at runtime.

When `httpx` is missing, the code falls back to a non-streaming `urllib` implementation (`gemini_stream_generate_iter`, line 244-249):

```python
if not HAS_HTTPX:
    # Fallback: non-streaming with urllib
    raw = gemini_stream_generate(prompt, model_id, think_mode)
    text = extract_response_text(raw)
    yield text
    return
```

This means:
- `stream: true` requests receive the **entire response in one SSE chunk** instead of incremental deltas
- No visible streaming in any client (Cherry Studio, ChatBox, curl, etc.)
- First-byte latency is significantly worse

## Fix

Add `RUN pip install --no-cache-dir httpx` to the Dockerfile, restoring the `httpx` streaming path that gives true per-delta SSE delivery.

## Reproduction

```bash
# Without the fix: entire response arrives in one chunk
docker compose up --build
curl -N http://localhost:8081/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"gemini-3.5-flash","messages":[{"role":"user","content":"Hello"}],"stream":true}'
```

## Test

- [x] `docker compose up --build` succeeds
- [x] Streaming response returns incremental SSE chunks
- [x] Non-streaming mode unaffected

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>