### PR TITLE
Support authenticated Gemini account routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,29 @@ Or use the JSON format:
 
 **Alternative (browser extension)**: Use any "Export Cookies" extension to export cookies for `gemini.google.com` in Netscape format, then convert to the single-line format above.
 
+### Authenticated account path and XSRF token
+
+If the signed-in Gemini page URL contains an account index, such as:
+
+```
+https://gemini.google.com/u/1/app/...
+```
+
+set `auth_user` to that index. Authenticated web requests may also require the page XSRF token. In the rendered Gemini page source, this token is exposed as `SNlM0e`; pass it as `xsrf_token` in `config.json`. The server sends it as the `at` form field.
+
+Example:
+
+```json
+{
+  "cookie_file": "/app/cookie.txt",
+  "auth_user": "1",
+  "xsrf_token": "AOOh0P...",
+  "gemini_bl": "boq_assistant-bard-web-server_YYYYMMDD.xx_p0"
+}
+```
+
+If authenticated requests return HTTP 400 with an `xsrf` error, refresh Gemini Web, update `xsrf_token`, and make sure `auth_user` matches the `/u/<index>/` part of the browser URL.
+
 No paid subscription needed — a free Google account is sufficient.
 
 ## Configuration
@@ -133,6 +156,9 @@ Create `config.json` in the same directory:
   "retry_attempts": 3,
   "retry_delay_sec": 2,
   "request_timeout_sec": 180,
+  "gemini_bl": "boq_assistant-bard-web-server_20260525.09_p0",
+  "auth_user": null,
+  "xsrf_token": null,
   "api_keys": ["sk-your-key"],
   "cookie_file": null,
   "proxy": null,

--- a/README_CN.md
+++ b/README_CN.md
@@ -120,6 +120,29 @@ SID=你的SID值; HSID=你的HSID值; SSID=你的SSID值; APISID=你的APISID值
 
 **替代方案 (浏览器扩展)**: 使用任意 "Export Cookies" 扩展导出 `gemini.google.com` 的 cookie, 然后转换为上述单行格式.
 
+### 登录账号路径与 XSRF Token
+
+如果已登录的 Gemini 页面 URL 带账号序号, 例如:
+
+```
+https://gemini.google.com/u/1/app/...
+```
+
+请把 `auth_user` 设置为该序号。登录态的 Gemini Web 请求还可能需要页面里的 XSRF token。该 token 在渲染后的 Gemini 页面源码中名为 `SNlM0e`; 在 `config.json` 中填入 `xsrf_token` 后, 服务会把它作为 `at` 表单字段提交。
+
+示例:
+
+```json
+{
+  "cookie_file": "/app/cookie.txt",
+  "auth_user": "1",
+  "xsrf_token": "AOOh0P...",
+  "gemini_bl": "boq_assistant-bard-web-server_YYYYMMDD.xx_p0"
+}
+```
+
+如果登录态请求返回 HTTP 400 且错误中包含 `xsrf`, 请刷新 Gemini Web 后更新 `xsrf_token`, 并确认 `auth_user` 与浏览器 URL 中的 `/u/<序号>/` 一致.
+
 不需要付费订阅 — 免费 Google 账号即可.
 
 ## 配置文件
@@ -133,6 +156,9 @@ SID=你的SID值; HSID=你的HSID值; SSID=你的SSID值; APISID=你的APISID值
   "retry_attempts": 3,
   "retry_delay_sec": 2,
   "request_timeout_sec": 180,
+  "gemini_bl": "boq_assistant-bard-web-server_20260525.09_p0",
+  "auth_user": null,
+  "xsrf_token": null,
   "api_keys": ["sk-your-key"],
   "cookie_file": null,
   "proxy": null,

--- a/config.example.json
+++ b/config.example.json
@@ -4,6 +4,9 @@
   "retry_attempts": 3,
   "retry_delay_sec": 2,
   "request_timeout_sec": 180,
+  "gemini_bl": "boq_assistant-bard-web-server_20260525.09_p0",
+  "auth_user": null,
+  "xsrf_token": null,
   "default_model": "gemini-3.5-flash",
   "api_keys": [
     "sk-gemini"

--- a/gemini_web2api.py
+++ b/gemini_web2api.py
@@ -52,6 +52,8 @@ DEFAULT_CONFIG = {
     "retry_delay_sec": 2,
     "request_timeout_sec": 180,
     "gemini_bl": "boq_assistant-bard-web-server_20260525.09_p0",
+    "auth_user": None,
+    "xsrf_token": None,
     "default_model": "gemini-3.5-flash",
     "log_requests": True,
     "cookie_file": None,
@@ -129,6 +131,14 @@ def make_sapisidhash(sapisid: str) -> str:
     return f"SAPISIDHASH {ts}_{h}"
 
 
+def account_prefix() -> str:
+    """Return the Gemini account path prefix for non-default Google accounts."""
+    auth_user = CONFIG.get("auth_user")
+    if auth_user is None or auth_user == "":
+        return ""
+    return f"/u/{auth_user}"
+
+
 # ─── Gemini Protocol ─────────────────────────────────────────────────────────
 
 def gemini_stream_generate(prompt: str, model_id: int, think_mode: int) -> str:
@@ -153,20 +163,26 @@ def gemini_stream_generate(prompt: str, model_id: int, think_mode: int) -> str:
     inner[79] = model_id
 
     outer = [None, json.dumps(inner)]
-    body = urllib.parse.urlencode({"f.req": json.dumps(outer)}).encode()
+    params = {"f.req": json.dumps(outer)}
+    if CONFIG.get("xsrf_token"):
+        params["at"] = CONFIG["xsrf_token"]
+    body = urllib.parse.urlencode(params).encode()
     reqid = int(time.time()) % 1000000
+    prefix = account_prefix()
     url = (
-        "https://gemini.google.com/_/BardChatUi/data/"
+        f"https://gemini.google.com{prefix}/_/BardChatUi/data/"
         "assistant.lamda.BardFrontendService/StreamGenerate"
         f"?bl={CONFIG['gemini_bl']}&hl=en&_reqid={reqid}&rt=c"
     )
     headers = {
         "Content-Type": "application/x-www-form-urlencoded",
         "Origin": "https://gemini.google.com",
-        "Referer": "https://gemini.google.com/app",
+        "Referer": f"https://gemini.google.com{prefix}/app",
         "X-Same-Domain": "1",
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
     }
+    if prefix:
+        headers["X-Goog-AuthUser"] = str(CONFIG["auth_user"])
 
     cookie_str, sapisid = load_cookie()
     if cookie_str:
@@ -219,20 +235,26 @@ def gemini_stream_generate_iter(prompt: str, model_id: int, think_mode: int):
     inner[79] = model_id
 
     outer = [None, json.dumps(inner)]
-    body = urllib.parse.urlencode({"f.req": json.dumps(outer)})
+    params = {"f.req": json.dumps(outer)}
+    if CONFIG.get("xsrf_token"):
+        params["at"] = CONFIG["xsrf_token"]
+    body = urllib.parse.urlencode(params)
     reqid = int(time.time()) % 1000000
+    prefix = account_prefix()
     url = (
-        "https://gemini.google.com/_/BardChatUi/data/"
+        f"https://gemini.google.com{prefix}/_/BardChatUi/data/"
         "assistant.lamda.BardFrontendService/StreamGenerate"
         f"?bl={CONFIG['gemini_bl']}&hl=en&_reqid={reqid}&rt=c"
     )
     headers = {
         "Content-Type": "application/x-www-form-urlencoded",
         "Origin": "https://gemini.google.com",
-        "Referer": "https://gemini.google.com/app",
+        "Referer": f"https://gemini.google.com{prefix}/app",
         "X-Same-Domain": "1",
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
     }
+    if prefix:
+        headers["X-Goog-AuthUser"] = str(CONFIG["auth_user"])
     cookie_str, sapisid = load_cookie()
     if cookie_str:
         headers["Cookie"] = cookie_str

--- a/gemini_web2api/config.py
+++ b/gemini_web2api/config.py
@@ -9,6 +9,8 @@ DEFAULT_CONFIG = {
     "retry_delay_sec": 2,
     "request_timeout_sec": 180,
     "gemini_bl": "boq_assistant-bard-web-server_20260525.09_p0",
+    "auth_user": None,
+    "xsrf_token": None,
     "default_model": "gemini-3.5-flash",
     "log_requests": True,
     "cookie_file": None,

--- a/gemini_web2api/gemini.py
+++ b/gemini_web2api/gemini.py
@@ -77,14 +77,25 @@ def make_sapisidhash(sapisid: str) -> str:
     return f"SAPISIDHASH {ts}_{h}"
 
 
+def _account_prefix() -> str:
+    """Return the Gemini account path prefix for non-default Google accounts."""
+    auth_user = CONFIG.get("auth_user")
+    if auth_user is None or auth_user == "":
+        return ""
+    return f"/u/{auth_user}"
+
+
 def _build_headers() -> dict:
+    account_prefix = _account_prefix()
     headers = {
         "Content-Type": "application/x-www-form-urlencoded",
         "Origin": "https://gemini.google.com",
-        "Referer": "https://gemini.google.com/app",
+        "Referer": f"https://gemini.google.com{account_prefix}/app",
         "X-Same-Domain": "1",
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
     }
+    if account_prefix:
+        headers["X-Goog-AuthUser"] = str(CONFIG["auth_user"])
     cookie_str, sapisid = load_cookie()
     if cookie_str:
         headers["Cookie"] = cookie_str
@@ -120,13 +131,17 @@ def _build_payload(prompt: str, model_id: int, think_mode: int, file_refs: list 
         for k, v in extra_fields.items():
             inner[k] = v
     outer = [None, json.dumps(inner)]
-    return urllib.parse.urlencode({"f.req": json.dumps(outer)})
+    params = {"f.req": json.dumps(outer)}
+    if CONFIG.get("xsrf_token"):
+        params["at"] = CONFIG["xsrf_token"]
+    return urllib.parse.urlencode(params)
 
 
 def _get_url() -> str:
     reqid = int(time.time()) % 1000000
+    account_prefix = _account_prefix()
     return (
-        "https://gemini.google.com/_/BardChatUi/data/"
+        f"https://gemini.google.com{account_prefix}/_/BardChatUi/data/"
         "assistant.lamda.BardFrontendService/StreamGenerate"
         f"?bl={CONFIG['gemini_bl']}&hl=en&_reqid={reqid}&rt=c"
     )


### PR DESCRIPTION
## Summary

This PR adds optional support for authenticated Gemini Web requests that use non-default Google account paths, such as `/u/1/`, and require the Gemini Web XSRF token.

## Problem

When using cookies from a signed-in Gemini account, some authenticated requests fail with `HTTP 400 Bad Request` or downstream `502` responses.

In my case, the root causes were:

1. Gemini Web requests for my signed-in account used `/u/1/_/BardChatUi/...`, while the proxy always requested `/_/BardChatUi/...`.
2. Authenticated Gemini Web requests required the page XSRF token exposed as `SNlM0e`, submitted as the `at` form field.
3. The request needed `X-Goog-AuthUser` to match the `/u/<index>/` account path.

Anonymous requests can still work without these fields, which makes the issue hard to diagnose until cookies are configured for real Pro routing.

## Changes

- Added optional `auth_user` config.
- Added optional `xsrf_token` config.
- Added `/u/<auth_user>` account path support for StreamGenerate requests.
- Added `X-Goog-AuthUser` header when `auth_user` is configured.
- Added `at=<xsrf_token>` to the form body when `xsrf_token` is configured.
- Updated `config.example.json`.
- Updated English and Chinese README docs with troubleshooting guidance.

## Compatibility

Default behavior is unchanged:

- If `auth_user` is unset, requests continue using `https://gemini.google.com/_/BardChatUi/...`.
- If `xsrf_token` is unset, only `f.req` is submitted as before.
- Anonymous mode remains unchanged.

## Testing

- Ran Python syntax checks:

```bash
python3 -m py_compile gemini_web2api.py gemini_web2api/*.py