### PR TITLE
Add PowerShell curl example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,22 @@ Server starts at `http://localhost:8081/v1`.
 
 ### curl
 
+#### bash / macOS / Linux
+
 ```bash
 curl http://localhost:8081/v1/chat/completions \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer sk-your-key" \
   -d '{"model":"gemini-3.5-flash","messages":[{"role":"user","content":"Hello!"}]}'
 ```
+
+#### PowerShell (Windows)
+
+```powershell
+curl.exe --% http://127.0.0.1:8081/v1/chat/completions -H "Content-Type: application/json" -H "Authorization: Bearer sk-your-key" -d "{\"model\":\"gemini-3.5-flash\",\"messages\":[{\"role\":\"user\",\"content\":\"Hello!\"}]}"
+```
+
+> Note: On Windows PowerShell, use `curl.exe` and `--%` so PowerShell does not reinterpret JSON quoting or curl options.
 
 ### OpenAI Python SDK
 


### PR DESCRIPTION
### Summary

Add a Windows PowerShell `curl` example to `README.md` alongside the existing bash/macOS/Linux example.

### Why

The existing README curl example is written for bash-style shells. On Windows PowerShell, JSON quoting and curl option parsing behave differently, so users need `curl.exe --% ...` to avoid PowerShell interpreting the JSON payload.

### Changes

- Added a `PowerShell (Windows)` curl example
- Included a note explaining why `curl.exe` and `--%` are needed in PowerShell

### Testing

- Verified the README text manually
- Confirmed the example uses PowerShell-compatible quoting for the JSON body

### Notes

This is a docs-only change and does not affect runtime behavior.