### PR TITLE
feat(docker): support multi-arch (amd64/arm64) builds in GitHub Actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -34,6 +40,7 @@ jobs:
       - uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
### Description
Currently, the Docker image published to `ghcr.io` is only built for `linux/amd64`. This PR updates the Docker publishing workflow to build and push multi-architecture images (supporting both `linux/amd64` and `linux/arm64`), making it compatible with Apple Silicon (ARM64) Macs and other ARM-based servers natively.

### Changes
- Added `docker/setup-qemu-action` to handle emulation for cross-platform builds.
- Added `docker/setup-buildx-action` to enable BuildKit builder with multi-platform support.
- Configured `platforms: linux/amd64,linux/arm64` in the `docker/build-push-action` step.

These changes are fully backward-compatible and require no modifications to the codebase or the Dockerfile.
