### PR TITLE
Update model and configuration for Gemini API

### DIFF
--- a/gemini_web2api.py
+++ b/gemini_web2api.py
@@ -51,10 +51,10 @@ DEFAULT_CONFIG = {
     "retry_attempts": 3,
     "retry_delay_sec": 2,
     "request_timeout_sec": 180,
-    "gemini_bl": "boq_assistant-bard-web-server_20260525.09_p0",
+    "gemini_bl": "boq_assistant-bard-web-server_20260716.08_p0",
     "auth_user": None,
     "xsrf_token": None,
-    "default_model": "gemini-3.5-flash",
+    "default_model": "gemini-3.6-flash",
     "log_requests": True,
     "cookie_file": None,
     "proxy": None,
@@ -68,9 +68,13 @@ CONFIG = dict(DEFAULT_CONFIG)
 #   1=FAST, 2=THINKING, 3=PRO, 4=AUTO, 5=FAST_DYNAMIC_THINKING, 6=FLASH_LITE
 
 MODELS = {
+    "gemini-3.6-flash": {
+        "mode": 1, "think": 4,
+        "desc": "Latest all-around model (Gemini 3.6 Flash)",
+    },
     "gemini-3.5-flash": {
         "mode": 1, "think": 4,
-        "desc": "Fast general-purpose model",
+        "desc": "Alias for gemini-3.6-flash (backend upgraded)",
     },
     "gemini-3.5-flash-thinking": {
         "mode": 2, "think": 0,


### PR DESCRIPTION
## 问题
- 该单文件仍使用旧的 gemini-3.5-flash、旧 gemini_bl，模型表中也没有 3.6，因此请求会返回 Unknown model: gemini-3.6-flash
- Google 于 2026 年 7 月 21 日发布 Gemini 3.6 Flash；仓库随后更新，但相关提交只修改了模块版代码，没有修改 README 默认运行的单文件版。

## 变更说明

- **默认模型设置更新**：`default_model` 切换至 `gemini-3.6-flash`。
- **配置与模型映射更新**：
  - 新增 `gemini-3.6-flash` 模型定义（`mode: 1`, `think: 4`）。
  - 更新 `gemini-3.5-flash` 的描述，标记其为 `gemini-3.6-flash` 的后端别名。
- **构建/服务版本号更新**：更新 `gemini_bl` 参数至 `20260716.08_p0` 版本。

## 测试

- [x] 已验证默认调用能够正确触发 `gemini-3.6-flash`。
- [x] 验证兼容性及模型参数正常解析。