### PR TITLE
fix: sync Gemini 3.6 support and improve streaming reliability

### DIFF
--- a/gemini_web2api.py
+++ b/gemini_web2api.py
@@ -280,6 +280,7 @@ def gemini_stream_generate_iter(prompt: str, model_id: int, think_mode: int):
     transport = httpx.HTTPTransport(proxy=proxy) if proxy else None
     with httpx.Client(transport=transport, timeout=CONFIG["request_timeout_sec"], verify=True) as client:
         with client.stream("POST", url, content=body, headers=headers) as resp:
+            resp.raise_for_status()
             buf = ""
             for chunk in resp.iter_text():
                 buf += chunk
@@ -304,7 +305,7 @@ def gemini_stream_generate_iter(prompt: str, model_id: int, think_mode: int):
                                     for t in part[1]:
                                         if isinstance(t, str) and len(t) > len(prev_text):
                                             delta = t[len(prev_text):]
-                                            delta = clean_gemini_text(delta)
+                                            delta = clean_gemini_text(delta, strip=False)
                                             if delta:
                                                 yield delta
                                             prev_text = t
@@ -312,13 +313,13 @@ def gemini_stream_generate_iter(prompt: str, model_id: int, think_mode: int):
                         pass
 
 
-def clean_gemini_text(text: str) -> str:
+def clean_gemini_text(text: str, strip: bool = True) -> str:
     """Remove internal code execution artifacts."""
     text = re.sub(
         r'```(?:python|javascript|text)\?code_(?:reference|stdout)&code_event_index=\d+\n.*?```\n?',
         '', text, flags=re.DOTALL
     )
-    return text.strip()
+    return text.strip() if strip else text
 
 
 def extract_response_text(raw: str) -> str:

--- a/gemini_web2api.py
+++ b/gemini_web2api.py
@@ -51,10 +51,10 @@ DEFAULT_CONFIG = {
     "retry_attempts": 3,
     "retry_delay_sec": 2,
     "request_timeout_sec": 180,
-    "gemini_bl": "boq_assistant-bard-web-server_20260525.09_p0",
+    "gemini_bl": "boq_assistant-bard-web-server_20260716.08_p0",
     "auth_user": None,
     "xsrf_token": None,
-    "default_model": "gemini-3.5-flash",
+    "default_model": "gemini-3.6-flash",
     "log_requests": True,
     "cookie_file": None,
     "proxy": None,
@@ -68,9 +68,13 @@ CONFIG = dict(DEFAULT_CONFIG)
 #   1=FAST, 2=THINKING, 3=PRO, 4=AUTO, 5=FAST_DYNAMIC_THINKING, 6=FLASH_LITE
 
 MODELS = {
+    "gemini-3.6-flash": {
+        "mode": 1, "think": 4,
+        "desc": "Latest all-around model (Gemini 3.6 Flash)",
+    },
     "gemini-3.5-flash": {
         "mode": 1, "think": 4,
-        "desc": "Fast general-purpose model",
+        "desc": "Alias for gemini-3.6-flash (backend upgraded)",
     },
     "gemini-3.5-flash-thinking": {
         "mode": 2, "think": 0,

--- a/gemini_web2api/gemini.py
+++ b/gemini_web2api/gemini.py
@@ -147,13 +147,13 @@ def _get_url() -> str:
     )
 
 
-def clean_text(text: str) -> str:
+def clean_text(text: str, strip: bool = True) -> str:
     text = re.sub(
         r'```(?:python|javascript|text)\?code_(?:reference|stdout)&code_event_index=\d+\n.*?```\n?',
         '', text, flags=re.DOTALL
     )
     text = re.sub(r'http://googleusercontent\.com/card_content/\d+\n?', '', text)
-    return text.strip()
+    return text.strip() if strip else text
 
 
 def _extract_texts_from_line(line: str) -> list:
@@ -181,6 +181,9 @@ def _extract_texts_from_line(line: str) -> list:
 
 def extract_response_text(raw: str) -> str:
     """Parse full response to get final text."""
+    bard_err = re.search(r'BardErrorInfo\s*\[(\d+)\]', raw)
+    if bard_err:
+        raise RuntimeError(f"Gemini upstream rejected request: BardErrorInfo [{bard_err.group(1)}]")
     last_text = ""
     for line in raw.split("\n"):
         for t in _extract_texts_from_line(line):
@@ -233,21 +236,31 @@ def generate_stream(prompt: str, model_id: int, think_mode: int, file_refs: list
     client = _get_httpx_client()
 
     last_err = None
+    emitted_raw_text = ""
     for attempt in range(CONFIG["retry_attempts"]):
         try:
-            prev_text = ""
             with client.stream("POST", url, content=body, headers=headers) as resp:
+                resp.raise_for_status()
                 buf = ""
                 for chunk in resp.iter_text():
                     buf += chunk
+                    if "BardErrorInfo" in buf:
+                        bard_err = re.search(r'BardErrorInfo\s*\[(\d+)\]', buf)
+                        if bard_err:
+                            raise RuntimeError(
+                                f"Gemini upstream rejected request: BardErrorInfo [{bard_err.group(1)}]"
+                            )
                     while "\n" in buf:
                         line, buf = buf.split("\n", 1)
                         for t in _extract_texts_from_line(line):
-                            if len(t) > len(prev_text):
-                                delta = clean_text(t[len(prev_text):])
-                                if delta:
-                                    yield delta
-                                prev_text = t
+                            if t == emitted_raw_text or emitted_raw_text.startswith(t):
+                                continue
+                            if not t.startswith(emitted_raw_text):
+                                raise RuntimeError("Gemini stream content changed during retry")
+                            delta = clean_text(t[len(emitted_raw_text):], strip=False)
+                            emitted_raw_text = t
+                            if delta:
+                                yield delta
             return
         except Exception as e:
             last_err = e


### PR DESCRIPTION
## Summary
- sync the single-file entry point with the Gemini 3.6 Flash default and current Gemini build label
- preserve whitespace in streamed response deltas
- prevent duplicated output when a streaming request reconnects and retries
- surface HTTP failures and `BardErrorInfo` responses in the modular client

## Validation
- `python -m compileall -q gemini_web2api gemini_web2api.py`
- deterministic streaming regression checks
  - `Hello` + ` world` produces `Hello world`
  - a simulated disconnect resumes without producing `HelloHello world`
  - `BardErrorInfo` is surfaced as an upstream error
- live streaming smoke tests returned `ALPHA BETA GAMMA` from both entry points