### PR TITLE
fix(models): add gemini-3.6-flash to single-file build

### DIFF
--- a/gemini_web2api.py
+++ b/gemini_web2api.py
@@ -68,9 +68,13 @@ CONFIG = dict(DEFAULT_CONFIG)
 #   1=FAST, 2=THINKING, 3=PRO, 4=AUTO, 5=FAST_DYNAMIC_THINKING, 6=FLASH_LITE
 
 MODELS = {
+    "gemini-3.6-flash": {
+        "mode": 1, "think": 4,
+        "desc": "Latest all-around model (Gemini 3.6 Flash)",
+    },
     "gemini-3.5-flash": {
         "mode": 1, "think": 4,
-        "desc": "Fast general-purpose model",
+        "desc": "Alias for gemini-3.6-flash (backend upgraded)",
     },
     "gemini-3.5-flash-thinking": {
         "mode": 2, "think": 0,


### PR DESCRIPTION
## Problem

Commit `d227668` added `gemini-3.6-flash` to the **package build** (`gemini_web2api/models.py`, `server.py`) but missed the **single-file** `gemini_web2api.py`, which ships its own `MODELS` map.

The single-file entry point is what the README and the pm2/systemd recipes actually run (`python gemini_web2api.py`), so after pulling `d227668` it rejects the new default model:

```json
{"error": {"message": "Unknown model: gemini-3.6-flash"}}
```

## Fix

Add the `gemini-3.6-flash` entry to the single-file `MODELS` map and mark `gemini-3.5-flash` as an alias — matching the package build and keeping both code forms in sync (the two-form trap this repo has).

```diff
 MODELS = {
+    "gemini-3.6-flash": {
+        "mode": 1, "think": 4,
+        "desc": "Latest all-around model (Gemini 3.6 Flash)",
+    },
     "gemini-3.5-flash": {
         "mode": 1, "think": 4,
-        "desc": "Fast general-purpose model",
+        "desc": "Alias for gemini-3.6-flash (backend upgraded)",
     },
```

## Verification

Deployed the single-file build and confirmed:
- `GET /v1/models` now lists `gemini-3.6-flash`
- `POST /v1/chat/completions` with `model: gemini-3.6-flash` returns a normal completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)
