### PR TITLE
feat(log): include client IP in access log

### DIFF
--- a/gemini_web2api.py
+++ b/gemini_web2api.py
@@ -426,7 +426,8 @@ def parse_tool_calls(text: str) -> tuple:
 
 class GeminiHandler(BaseHTTPRequestHandler):
     def log_message(self, fmt, *args):
-        log(fmt % args)
+        client_ip = self.client_address[0] if self.client_address else "-"
+        log(f"{client_ip} {fmt % args}")
 
     def send_json(self, data, status=200):
         body = json.dumps(data, ensure_ascii=False).encode()

--- a/gemini_web2api/server.py
+++ b/gemini_web2api/server.py
@@ -42,7 +42,8 @@ def _upload_images(images: list) -> list:
 
 class GeminiHandler(BaseHTTPRequestHandler):
     def log_message(self, fmt, *args):
-        log(fmt % args)
+        client_ip = self.client_address[0] if self.client_address else "-"
+        log(f"{client_ip} {fmt % args}")
 
     def send_json(self, data, status=200):
         body = json.dumps(data, ensure_ascii=False).encode()


### PR DESCRIPTION
## Problem

`GeminiHandler.log_message` overrides the default `BaseHTTPRequestHandler.log_message` but drops the client address (`address_string()`), so every request is logged as only:

```
[14:57:12] "POST /v1/chat/completions HTTP/1.1" 401 -
```

There is **no client IP**, which makes abusive clients untraceable from the app log — I had to `tcpdump` to find an IP hitting `/v1/chat/completions` with a bad key every 5 minutes.

## Fix

Prepend the client IP to every log line:

```
[14:57:12] 1.2.3.4 "POST /v1/chat/completions HTTP/1.1" 401 -
```

Applied to **both** code forms (`gemini_web2api.py` single-file and `gemini_web2api/server.py` package) to keep them in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
