### PR TITLE
fix: sync recent streaming and temporary chat changes to modular package

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,9 +174,13 @@ Create `config.json` in the same directory:
   "api_keys": ["sk-your-key"],
   "cookie_file": null,
   "proxy": null,
-  "log_requests": true
+  "log_requests": true,
+  "temporary_chats": false
 }
 ```
+
+Set `temporary_chats` to `true` to use Gemini Web temporary chats instead of
+persisting conversations to the account history.
 
 When `api_keys` is `[]`, authentication is disabled. When one or more keys are set, `/v1/*` endpoints require `Authorization: Bearer <key>` or `x-api-key: <key>`.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -164,9 +164,13 @@ Pro 路由需要 **Gemini Advanced** (付费订阅). 免费 Google 账号的 coo
   "api_keys": ["sk-your-key"],
   "cookie_file": null,
   "proxy": null,
-  "log_requests": true
+  "log_requests": true,
+  "temporary_chats": false
 }
 ```
+
+将 `temporary_chats` 设置为 `true` 后，请求会使用 Gemini 网页版的临时聊天，
+不会将对话保存在账号历史记录中。
 
 `api_keys` 为空数组 `[]` 时不校验密钥；填入一个或多个密钥后, `/v1/*` 接口需要 `Authorization: Bearer <key>` 或 `x-api-key: <key>`.
 

--- a/gemini_web2api/__main__.py
+++ b/gemini_web2api/__main__.py
@@ -38,6 +38,7 @@ def main():
     print(f"  Cookie:    {'yes' if CONFIG.get('cookie_file') else 'none (anonymous)'}")
     print(f"  Proxy:     {CONFIG.get('proxy') or 'system env'}")
     print(f"  Streaming: {'httpx (true streaming)' if HAS_HTTPX else 'urllib (buffered)'}")
+    print(f"  Temporary: {'yes' if CONFIG.get('temporary_chats', False) else 'no'}")
     print()
     try:
         server.serve_forever()

--- a/gemini_web2api/config.py
+++ b/gemini_web2api/config.py
@@ -16,6 +16,7 @@ DEFAULT_CONFIG = {
     "cookie_file": None,
     "proxy": None,
     "api_keys": [],
+    "temporary_chats": False,
 }
 
 CONFIG = dict(DEFAULT_CONFIG)

--- a/gemini_web2api/gemini.py
+++ b/gemini_web2api/gemini.py
@@ -104,6 +104,16 @@ def _build_headers() -> dict:
     return headers
 
 
+def _apply_chat_persistence_flags(inner: list) -> None:
+    """Apply Gemini Web persistence flags to an outgoing request payload."""
+    if CONFIG.get("temporary_chats", False):
+        # Match Gemini Web temporary-chat requests.
+        inner[41] = [1]
+        inner[45] = 1
+    else:
+        inner[41] = [2]
+
+
 def _build_payload(prompt: str, model_id: int, think_mode: int, file_refs: list = None, extra_fields: dict = None) -> str:
     inner = [None] * 102
     if file_refs:
@@ -121,7 +131,7 @@ def _build_payload(prompt: str, model_id: int, think_mode: int, file_refs: list 
     inner[18] = 0
     inner[27] = 1
     inner[30] = [4]
-    inner[41] = [2]
+    _apply_chat_persistence_flags(inner)
     inner[53] = 0
     inner[59] = str(uuid.uuid4())
     inner[61] = []

--- a/gemini_web2api/server.py
+++ b/gemini_web2api/server.py
@@ -169,6 +169,19 @@ class GeminiHandler(BaseHTTPRequestHandler):
         if stream and (not tools or tool_choice == "none"):
             try:
                 self._start_sse()
+                first_chunk = {
+                    "id": cid,
+                    "object": "chat.completion.chunk",
+                    "created": int(time.time()),
+                    "model": model_name,
+                    "choices": [{
+                        "index": 0,
+                        "delta": {"role": "assistant"},
+                        "finish_reason": None,
+                    }],
+                }
+                self.wfile.write(f"data: {json.dumps(first_chunk)}\n\n".encode())
+                self.wfile.flush()
                 for delta in generate_stream(prompt, model_id, think_mode, _upload_images(images), extra_fields):
                     chunk = {"id": cid, "object": "chat.completion.chunk", "created": int(time.time()),
                              "model": model_name, "choices": [{"index": 0, "delta": {"content": delta}, "finish_reason": None}]}
@@ -296,24 +309,139 @@ class GeminiHandler(BaseHTTPRequestHandler):
                            "content": [{"type": "output_text", "text": text or "", "annotations": []}]})
 
         if req.get("stream"):
-            self.send_response(200)
-            self.send_header("Content-Type", "text/event-stream")
-            self.send_header("Cache-Control", "no-cache")
-            self.send_header("Access-Control-Allow-Origin", "*")
-            self.end_headers()
-            ev = {"type": "response.created", "response": {"id": rid, "object": "response", "status": "in_progress", "model": model_name, "output": []}}
-            self.wfile.write(f"event: response.created\ndata: {json.dumps(ev)}\n\n".encode())
-            for item in output:
+            self._start_sse()
+            sequence_number = 0
+
+            def emit(event_type, **fields):
+                nonlocal sequence_number
+                sequence_number += 1
+                event = {
+                    "type": event_type,
+                    "sequence_number": sequence_number,
+                    **fields,
+                }
+                self.wfile.write(
+                    f"event: {event_type}\ndata: {json.dumps(event)}\n\n".encode()
+                )
+
+            usage = {
+                "input_tokens": len(prompt) // 4,
+                "output_tokens": len(text or "") // 4,
+                "total_tokens": (len(prompt) + len(text or "")) // 4,
+            }
+            base_response = {
+                "id": rid,
+                "object": "response",
+                "created_at": int(time.time()),
+                "model": model_name,
+            }
+            emit(
+                "response.created",
+                response={
+                    **base_response,
+                    "status": "in_progress",
+                    "output": [],
+                    "usage": None,
+                },
+            )
+            emit(
+                "response.in_progress",
+                response={
+                    **base_response,
+                    "status": "in_progress",
+                    "output": [],
+                    "usage": None,
+                },
+            )
+            for output_index, item in enumerate(output):
                 if item["type"] == "function_call":
-                    ev = {"type": "response.function_call_arguments.done", "item_id": item["id"], "call_id": item["call_id"], "name": item["name"], "arguments": item["arguments"]}
-                    self.wfile.write(f"event: response.function_call_arguments.done\ndata: {json.dumps(ev)}\n\n".encode())
+                    pending_item = {
+                        "type": "function_call",
+                        "id": item["id"],
+                        "call_id": item["call_id"],
+                        "name": item["name"],
+                        "arguments": "",
+                        "status": "in_progress",
+                    }
+                    emit(
+                        "response.output_item.added",
+                        output_index=output_index,
+                        item=pending_item,
+                    )
+                    emit(
+                        "response.function_call_arguments.delta",
+                        item_id=item["id"],
+                        output_index=output_index,
+                        delta=item["arguments"],
+                    )
+                    emit(
+                        "response.function_call_arguments.done",
+                        item_id=item["id"],
+                        output_index=output_index,
+                        arguments=item["arguments"],
+                    )
+                    emit(
+                        "response.output_item.done",
+                        output_index=output_index,
+                        item=item,
+                    )
                 elif item["type"] == "message":
-                    for ci, cp in enumerate(item["content"]):
-                        ev = {"type": "response.output_text.done", "item_id": item["id"], "content_index": ci, "text": cp["text"]}
-                        self.wfile.write(f"event: response.output_text.done\ndata: {json.dumps(ev)}\n\n".encode())
-            resp_obj = {"id": rid, "object": "response", "status": "completed", "model": model_name, "output": output,
-                        "usage": {"input_tokens": len(prompt)//4, "output_tokens": len(text or "")//4, "total_tokens": (len(prompt)+len(text or ""))//4}}
-            self.wfile.write(f"event: response.completed\ndata: {json.dumps({'type': 'response.completed', 'response': resp_obj})}\n\n".encode())
+                    pending_item = {
+                        "type": "message",
+                        "id": item["id"],
+                        "role": "assistant",
+                        "status": "in_progress",
+                        "content": [],
+                    }
+                    emit(
+                        "response.output_item.added",
+                        output_index=output_index,
+                        item=pending_item,
+                    )
+                    for content_index, content_part in enumerate(item["content"]):
+                        event_fields = {
+                            "item_id": item["id"],
+                            "output_index": output_index,
+                            "content_index": content_index,
+                        }
+                        emit(
+                            "response.content_part.added",
+                            **event_fields,
+                            part={
+                                "type": "output_text",
+                                "text": "",
+                                "annotations": [],
+                            },
+                        )
+                        emit(
+                            "response.output_text.delta",
+                            **event_fields,
+                            delta=content_part["text"],
+                        )
+                        emit(
+                            "response.output_text.done",
+                            **event_fields,
+                            text=content_part["text"],
+                        )
+                        emit(
+                            "response.content_part.done",
+                            **event_fields,
+                            part=content_part,
+                        )
+                    emit(
+                        "response.output_item.done",
+                        output_index=output_index,
+                        item=item,
+                    )
+            emit(
+                "response.completed",
+                response={
+                    **base_response,
+                    "status": "completed",
+                    "output": output,
+                    "usage": usage,
+                },
+            )
             self.wfile.flush()
         else:
             self.send_json({"id": rid, "object": "response", "created_at": int(time.time()), "status": "completed",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for gemini-web2api."""

--- a/tests/test_modular_sync.py
+++ b/tests/test_modular_sync.py
@@ -1,0 +1,219 @@
+import http.client
+import json
+import threading
+import unittest
+from unittest import mock
+from urllib.parse import parse_qs
+
+from gemini_web2api.config import CONFIG, DEFAULT_CONFIG
+from gemini_web2api.gemini import _build_payload
+from gemini_web2api.server import GeminiHandler, ThreadedServer
+
+
+def _decode_payload(payload):
+    outer = json.loads(parse_qs(payload)["f.req"][0])
+    return json.loads(outer[1])
+
+
+def _decode_sse(body):
+    events = []
+    for block in body.strip().split("\n\n"):
+        lines = block.splitlines()
+        event_type = next(
+            (line[len("event: "):] for line in lines if line.startswith("event: ")),
+            None,
+        )
+        data = next(
+            (line[len("data: "):] for line in lines if line.startswith("data: ")),
+            None,
+        )
+        if event_type and data:
+            events.append((event_type, json.loads(data)))
+    return events
+
+
+class PayloadPersistenceTests(unittest.TestCase):
+    def setUp(self):
+        self.original_config = dict(CONFIG)
+
+    def tearDown(self):
+        CONFIG.clear()
+        CONFIG.update(self.original_config)
+
+    def test_temporary_chats_default_to_disabled(self):
+        self.assertIs(DEFAULT_CONFIG["temporary_chats"], False)
+
+    def test_persistent_chat_payload(self):
+        CONFIG["temporary_chats"] = False
+
+        inner = _decode_payload(_build_payload("hello", 1, 4))
+
+        self.assertEqual(inner[41], [2])
+        self.assertIsNone(inner[45])
+
+    def test_temporary_chat_payload(self):
+        CONFIG["temporary_chats"] = True
+
+        inner = _decode_payload(_build_payload("hello", 1, 4))
+
+        self.assertEqual(inner[41], [1])
+        self.assertEqual(inner[45], 1)
+
+
+class StreamingEndpointTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.server = ThreadedServer(("127.0.0.1", 0), GeminiHandler)
+        cls.thread = threading.Thread(target=cls.server.serve_forever, daemon=True)
+        cls.thread.start()
+        cls.port = cls.server.server_address[1]
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.server.server_close()
+        cls.thread.join(timeout=5)
+
+    def setUp(self):
+        self.original_config = dict(CONFIG)
+        CONFIG["api_keys"] = []
+        CONFIG["log_requests"] = False
+
+    def tearDown(self):
+        CONFIG.clear()
+        CONFIG.update(self.original_config)
+
+    def post_json(self, path, payload):
+        connection = http.client.HTTPConnection("127.0.0.1", self.port, timeout=5)
+        connection.request(
+            "POST",
+            path,
+            body=json.dumps(payload),
+            headers={"Content-Type": "application/json"},
+        )
+        response = connection.getresponse()
+        body = response.read().decode()
+        headers = dict(response.getheaders())
+        connection.close()
+        return response.status, headers, body
+
+    @mock.patch("gemini_web2api.server.generate_stream")
+    def test_chat_stream_starts_with_assistant_role(self, generate_stream):
+        generate_stream.return_value = iter(["hel", "lo"])
+
+        status, headers, body = self.post_json(
+            "/v1/chat/completions",
+            {
+                "model": "gemini-3.6-flash",
+                "messages": [{"role": "user", "content": "hello"}],
+                "stream": True,
+            },
+        )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(headers["Content-Type"], "text/event-stream")
+        chunks = [
+            json.loads(line[len("data: "):])
+            for line in body.splitlines()
+            if line.startswith("data: {")
+        ]
+        self.assertEqual(chunks[0]["choices"][0]["delta"], {"role": "assistant"})
+        self.assertEqual(chunks[1]["choices"][0]["delta"], {"content": "hel"})
+        self.assertEqual(chunks[2]["choices"][0]["delta"], {"content": "lo"})
+        self.assertTrue(body.endswith("data: [DONE]\n\n"))
+
+    @mock.patch("gemini_web2api.server.generate", return_value="hello")
+    def test_responses_text_stream_has_complete_event_sequence(self, _generate):
+        status, headers, body = self.post_json(
+            "/v1/responses",
+            {
+                "model": "gemini-3.6-flash",
+                "input": "hello",
+                "stream": True,
+            },
+        )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(headers["Content-Type"], "text/event-stream")
+        events = _decode_sse(body)
+        self.assertEqual(
+            [event_type for event_type, _ in events],
+            [
+                "response.created",
+                "response.in_progress",
+                "response.output_item.added",
+                "response.content_part.added",
+                "response.output_text.delta",
+                "response.output_text.done",
+                "response.content_part.done",
+                "response.output_item.done",
+                "response.completed",
+            ],
+        )
+        self.assertEqual(
+            [event["sequence_number"] for _, event in events],
+            list(range(1, len(events) + 1)),
+        )
+        self.assertEqual(events[4][1]["delta"], "hello")
+        self.assertEqual(events[-1][1]["response"]["status"], "completed")
+        self.assertEqual(events[-1][1]["response"]["output"][0]["content"][0]["text"], "hello")
+
+    @mock.patch("gemini_web2api.server.parse_tool_calls")
+    @mock.patch("gemini_web2api.server.generate", return_value="tool output")
+    def test_responses_function_call_stream_has_complete_event_sequence(
+        self, _generate, parse_tool_calls
+    ):
+        parse_tool_calls.return_value = (
+            "",
+            [
+                {
+                    "id": "call_test",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": '{"city":"Shanghai"}'},
+                }
+            ],
+        )
+
+        status, _, body = self.post_json(
+            "/v1/responses",
+            {
+                "model": "gemini-3.6-flash",
+                "input": "weather",
+                "tools": [
+                    {
+                        "type": "function",
+                        "name": "get_weather",
+                        "description": "Get weather",
+                        "parameters": {"type": "object"},
+                    }
+                ],
+                "stream": True,
+            },
+        )
+
+        self.assertEqual(status, 200)
+        events = _decode_sse(body)
+        self.assertEqual(
+            [event_type for event_type, _ in events],
+            [
+                "response.created",
+                "response.in_progress",
+                "response.output_item.added",
+                "response.function_call_arguments.delta",
+                "response.function_call_arguments.done",
+                "response.output_item.done",
+                "response.completed",
+            ],
+        )
+        self.assertEqual(
+            [event["sequence_number"] for _, event in events],
+            list(range(1, len(events) + 1)),
+        )
+        self.assertEqual(events[2][1]["output_index"], 0)
+        self.assertEqual(events[3][1]["delta"], '{"city":"Shanghai"}')
+        self.assertEqual(events[4][1]["arguments"], '{"city":"Shanghai"}')
+        self.assertEqual(events[-1][1]["response"]["output"][0]["name"], "get_weather")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 修改内容

将根目录单文件版本的近期修复同步到 Docker 和 Python 包实际使用的模块化版本：

- 同步 `temporary_chats` 配置及 Gemini 请求标志
- 为 Chat Completions 流式响应首块增加 `assistant` 角色
- 补齐 Responses API 文本及函数调用的标准 SSE 事件序列
- 增加 `sequence_number`、`output_index` 等事件字段
- 补充中英文配置文档
- 新增模块化版本回归测试

## 背景

Dockerfile 运行的是 `python -m gemini_web2api`，即 `gemini_web2api/` 模块化包。

近期相关修复只更新了根目录的 `gemini_web2api.py`，因此 Docker 镜像没有包含这些改动。本 PR 将相关变更同步到模块化实现，使 Docker、Python 包与单文件版本的行为保持一致。

## 验证结果

- `python3 -m unittest discover -v`：6 个测试通过
- `git diff --check`：通过
- Python 3.8 语法兼容检查：通过
- Docker 镜像构建：通过
- 独立容器冒烟测试：通过
