### PR TITLE
feat: add OpenAI multimodal input support

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,9 +248,27 @@ resp = client.chat.completions.create(
 )
 ```
 
+## Image Input
+
+OpenAI-style multimodal messages are supported for Chat Completions and the
+Responses API. Use either HTTP(S) image URLs or base64 data URLs:
+
+```python
+resp = client.chat.completions.create(
+    model="gemini-3.6-flash",
+    messages=[{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Describe this image"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/image.png"}}
+        ]
+    }]
+)
+```
+
 ## Limitations
 
-- **No image/multimodal input**: Gemini's image upload requires a proprietary streaming RPC protocol (WIZ/ProcessFile) that cannot be replicated in a standard HTTP proxy. Image inputs in messages will be ignored with a note.
+- **Image upload may require cookies**: Multimodal input uses Gemini Web's image upload endpoint. If anonymous upload fails, configure a Gemini cookie.
 - **Not real Pro/Ultra**: Without a paid subscription cookie, `gemini-3.1-pro` routes to the same Flash model. The "Pro" label is a UI preference, not a backend model switch.
 - **Single-turn only**: Each request is an independent conversation. Multi-turn context is simulated by including previous messages in the prompt.
 - **Rate limits**: Google may throttle high-frequency requests. The server retries automatically but sustained heavy use may be blocked.

--- a/README_CN.md
+++ b/README_CN.md
@@ -221,9 +221,27 @@ python gemini_web2api.py
 
 支持 Clash, V2Ray, Shadowsocks 等任何 HTTP 代理.
 
+## 图片输入
+
+Chat Completions 和 Responses API 支持 OpenAI 风格的多模态消息。图片可以使用
+HTTP(S) URL 或 base64 data URL:
+
+```python
+resp = client.chat.completions.create(
+    model="gemini-3.6-flash",
+    messages=[{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "描述这张图片"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/image.png"}}
+        ]
+    }]
+)
+```
+
 ## 已知限制
 
-- **不支持图片/多模态输入**: Gemini 的图片上传需要专有的 WIZ streaming RPC 协议 (ProcessFile), 无法在标准 HTTP 代理中实现. 发送图片会被忽略并返回提示.
+- **图片上传可能需要 Cookie**: 多模态输入使用 Gemini 网页端图片上传接口。匿名上传失败时, 请配置 Gemini cookie。
 - **Pro/Ultra 非真实路由**: 无付费订阅 cookie 时, `gemini-3.1-pro` 实际路由到 Flash 模型. "Pro" 只是 UI 偏好标签.
 - **单轮对话**: 每次请求是独立对话, 多轮上下文通过在 prompt 中包含历史消息模拟.
 - **频率限制**: Google 可能限制高频请求, server 会自动重试但持续高负载可能被封.

--- a/gemini_web2api.py
+++ b/gemini_web2api.py
@@ -32,6 +32,8 @@ import os
 import hashlib
 import argparse
 import base64
+import binascii
+from typing import Optional
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from socketserver import ThreadingMixIn
 
@@ -154,7 +156,7 @@ def apply_chat_persistence_flags(inner: list) -> None:
         inner[41] = [2]
 
 
-def fetch_latest_bl() -> str | None:
+def fetch_latest_bl() -> Optional[str]:
     """Fetch the latest gemini_bl from gemini.google.com page."""
     try:
         req = urllib.request.Request(
@@ -188,12 +190,40 @@ def update_bl_if_needed() -> bool:
     return False
 
 
+def upload_images(images: list) -> list:
+    """Upload parsed OpenAI image parts and return Gemini file references."""
+    if not images:
+        return None
+    from gemini_web2api.multimodal import detect_image_mime, fetch_image_bytes, upload_image
+
+    file_refs = []
+    for item in images:
+        if not (isinstance(item, tuple) and len(item) == 2):
+            continue
+        data, mime = item
+        if isinstance(data, str):
+            data = fetch_image_bytes(data)
+            mime = mime or "image/png"
+        if not data:
+            raise RuntimeError("image fetch failed")
+        mime = detect_image_mime(data, mime or "image/png")
+        try:
+            file_refs.append(upload_image(data, "image.png", mime or "image/png"))
+        except Exception as e:
+            raise RuntimeError(f"image upload failed: {e}") from e
+    return file_refs if file_refs else None
+
+
 # ─── Gemini Protocol ─────────────────────────────────────────────────────────
 
-def gemini_stream_generate(prompt: str, model_id: int, think_mode: int) -> str:
+def gemini_stream_generate(prompt: str, model_id: int, think_mode: int, file_refs: list = None) -> str:
     """Send prompt to Gemini StreamGenerate with retry."""
     inner = [None] * 80
-    inner[0] = [prompt, 0, None, None, None, None, 0]
+    if file_refs:
+        refs = [[None, None, ref] for ref in file_refs]
+        inner[0] = [prompt, 0, None, refs, None, None, 0]
+    else:
+        inner[0] = [prompt, 0, None, None, None, None, 0]
     inner[1] = ["en"]
     inner[2] = ["", "", "", None, None, None, None, None, None, ""]
     inner[6] = [0]
@@ -277,10 +307,14 @@ def gemini_stream_generate(prompt: str, model_id: int, think_mode: int) -> str:
     raise last_err
 
 
-def gemini_stream_generate_iter(prompt: str, model_id: int, think_mode: int):
+def gemini_stream_generate_iter(prompt: str, model_id: int, think_mode: int, file_refs: list = None):
     """Send prompt and yield incremental text deltas using httpx streaming."""
     inner = [None] * 80
-    inner[0] = [prompt, 0, None, None, None, None, 0]
+    if file_refs:
+        refs = [[None, None, ref] for ref in file_refs]
+        inner[0] = [prompt, 0, None, refs, None, None, 0]
+    else:
+        inner[0] = [prompt, 0, None, None, None, None, 0]
     inner[1] = ["en"]
     inner[2] = ["", "", "", None, None, None, None, None, None, ""]
     inner[6] = [0]
@@ -329,7 +363,7 @@ def gemini_stream_generate_iter(prompt: str, model_id: int, think_mode: int):
 
     if not HAS_HTTPX:
         # Fallback: non-streaming with urllib
-        raw = gemini_stream_generate(prompt, model_id, think_mode)
+        raw = gemini_stream_generate(prompt, model_id, think_mode, file_refs)
         text = extract_response_text(raw)
         if text:
             yield text
@@ -375,7 +409,7 @@ def gemini_stream_generate_iter(prompt: str, model_id: int, think_mode: int):
             if HAS_HTTPX and hasattr(e, 'response') and getattr(e.response, 'status_code', 0) == 405:
                 if update_bl_if_needed():
                     log("BL updated, falling back to non-streaming for this request")
-                    raw = gemini_stream_generate(prompt, model_id, think_mode)
+                    raw = gemini_stream_generate(prompt, model_id, think_mode, file_refs)
                     text = extract_response_text(raw)
                     if text:
                         yield text
@@ -429,9 +463,59 @@ def extract_response_text(raw: str) -> str:
 
 PROMPT_MAX_BYTES = 60000
 
-def messages_to_prompt(messages: list, tools: list = None) -> str:
-    """Convert OpenAI messages to prompt string."""
+
+def decode_data_url(url: str):
+    match = re.match(r"^data:([^;,]+)?(;base64)?,(.*)$", url, re.DOTALL)
+    if not match:
+        return None
+    mime = match.group(1) or "image/png"
+    is_base64 = bool(match.group(2))
+    data = match.group(3)
+    try:
+        if is_base64:
+            return base64.b64decode(data, validate=True), mime
+        return urllib.parse.unquote_to_bytes(data), mime
+    except (ValueError, TypeError, binascii.Error):
+        return None
+
+
+def image_from_url(url: str, mime: str = None):
+    if not isinstance(url, str) or not url:
+        return None
+    if url.startswith("data:"):
+        return decode_data_url(url)
+    return url, mime or "image/png"
+
+
+def image_from_part(part: dict):
+    part_type = part.get("type")
+    if part_type == "image_url":
+        image_url = part.get("image_url", {})
+        if isinstance(image_url, dict):
+            return image_from_url(image_url.get("url"), image_url.get("mime_type"))
+        return image_from_url(image_url)
+    if part_type in ("input_image", "image"):
+        image_url = part.get("image_url") or part.get("url")
+        if isinstance(image_url, dict):
+            return image_from_url(image_url.get("url"), image_url.get("mime_type"))
+        if image_url:
+            return image_from_url(image_url, part.get("mime_type"))
+        image_data = part.get("data") or part.get("base64")
+        if isinstance(image_data, str):
+            mime = part.get("mime_type") or part.get("media_type") or "image/png"
+            if image_data.startswith("data:"):
+                return decode_data_url(image_data)
+            try:
+                return base64.b64decode(image_data, validate=True), mime
+            except (ValueError, TypeError, binascii.Error):
+                return None
+    return None
+
+
+def messages_to_prompt(messages: list, tools: list = None) -> tuple:
+    """Convert OpenAI messages to (prompt_str, images_list)."""
     parts = []
+    images = []
     if tools:
         tool_defs = []
         for tool in tools:
@@ -458,10 +542,16 @@ def messages_to_prompt(messages: list, tools: list = None) -> str:
         role = msg.get("role", "user")
         content = msg.get("content", "")
         if isinstance(content, list):
-            content = " ".join(
-                c.get("text", "") for c in content
-                if c.get("type") in ("text", "input_text")
-            )
+            text_parts = []
+            for c in content:
+                if c.get("type") in ("text", "input_text", "output_text"):
+                    text_parts.append(c.get("text", ""))
+                else:
+                    image = image_from_part(c)
+                    if image:
+                        images.append(image)
+                        text_parts.append("[Image attached]")
+            content = " ".join(text_parts)
         if role == "system":
             parts.append(f"[System instruction]: {content}")
         elif role == "assistant":
@@ -480,7 +570,45 @@ def messages_to_prompt(messages: list, tools: list = None) -> str:
             parts.append(f"[Tool result for {msg.get('name', '')}]: {content}")
         else:
             parts.append(content if content else "")
-    return "\n\n".join(p for p in parts if p)
+    return "\n\n".join(p for p in parts if p), images
+
+
+def google_contents_to_prompt(req: dict) -> tuple:
+    """Convert Google API contents to (prompt_str, images_list)."""
+    parts = []
+    images = []
+
+    sys_inst = req.get("systemInstruction")
+    if sys_inst:
+        sys_text = " ".join(
+            part.get("text", "") for part in sys_inst.get("parts", []) if part.get("text")
+        )
+        if sys_text:
+            parts.append(f"[System instruction]: {sys_text}")
+
+    for content in req.get("contents", []):
+        role = content.get("role", "user")
+        text_parts = []
+        for part in content.get("parts", []):
+            if part.get("text"):
+                text_parts.append(part["text"])
+            elif part.get("inlineData"):
+                data = part["inlineData"]
+                try:
+                    images.append((
+                        base64.b64decode(data["data"], validate=True),
+                        data.get("mimeType", "image/png"),
+                    ))
+                    text_parts.append("[Image attached]")
+                except (KeyError, ValueError, TypeError, binascii.Error):
+                    pass
+        text = " ".join(text_parts)
+        if role == "model":
+            parts.append(f"[Assistant]: {text}")
+        else:
+            parts.append(text)
+
+    return "\n\n".join(part for part in parts if part), images
 
 
 def parse_tool_calls(text: str) -> tuple:
@@ -574,16 +702,15 @@ class GeminiHandler(BaseHTTPRequestHandler):
             if self.path.startswith("/v1") and not self._authorized():
                 self.send_json({"error": {"message": "invalid api key"}}, 401)
                 return
-            length = int(self.headers.get("Content-Length", 0))
-            body = self.rfile.read(length) if length else b""
+            body = self._read_request_body()
             if self.path == "/v1/chat/completions":
                 self.handle_chat(body)
             elif self.path == "/v1/responses":
                 self.handle_responses(body)
-            elif ":generateContent" in self.path:
-                self._handle_google_generate(body, stream=False)
             elif ":streamGenerateContent" in self.path:
                 self._handle_google_generate(body, stream=True)
+            elif ":generateContent" in self.path:
+                self._handle_google_generate(body, stream=False)
             else:
                 self.send_json({"error": "not found"}, 404)
         except (BrokenPipeError, ConnectionResetError):
@@ -595,6 +722,32 @@ class GeminiHandler(BaseHTTPRequestHandler):
             except:
                 pass
 
+    def _read_request_body(self) -> bytes:
+        transfer_encoding = self.headers.get("Transfer-Encoding", "")
+        if "chunked" in transfer_encoding.lower():
+            chunks = []
+            while True:
+                size_line = self.rfile.readline()
+                if not size_line:
+                    break
+                size_text = size_line.split(b";", 1)[0].strip()
+                try:
+                    size = int(size_text, 16)
+                except ValueError:
+                    raise ValueError("invalid chunked request body")
+                if size == 0:
+                    while True:
+                        trailer = self.rfile.readline()
+                        if trailer in (b"\r\n", b"\n", b""):
+                            break
+                    break
+                chunks.append(self.rfile.read(size))
+                self.rfile.read(2)
+            return b"".join(chunks)
+
+        length = int(self.headers.get("Content-Length", 0))
+        return self.rfile.read(length) if length else b""
+
     def _resolve_model(self, model_name):
         think_override = None
         if "@think=" in model_name:
@@ -605,8 +758,8 @@ class GeminiHandler(BaseHTTPRequestHandler):
             return None, None, None, f"Unknown model: {model_name}"
         return model_name, cfg["mode"], (think_override if think_override is not None else cfg["think"]), None
 
-    def _call_gemini(self, prompt, model_id, think_mode, tools):
-        raw = gemini_stream_generate(prompt, model_id, think_mode)
+    def _call_gemini(self, prompt, model_id, think_mode, tools, file_refs=None):
+        raw = gemini_stream_generate(prompt, model_id, think_mode, file_refs)
         text = extract_response_text(raw)
         tool_calls = None
         if tools and text:
@@ -622,13 +775,18 @@ class GeminiHandler(BaseHTTPRequestHandler):
             return
 
         tools = req.get("tools")
-        prompt = messages_to_prompt(req.get("messages", []), tools)
+        prompt, images = messages_to_prompt(req.get("messages", []), tools)
         if not prompt.strip():
             self.send_json({"error": {"message": "empty prompt"}}, 400)
             return
 
         stream = req.get("stream", False)
         cid = f"chatcmpl-{uuid.uuid4().hex[:12]}"
+        try:
+            file_refs = upload_images(images)
+        except RuntimeError as e:
+            self.send_json({"error": {"message": f"upstream error: {e}"}}, 502)
+            return
 
         if stream and not tools:
             # True streaming: forward chunks as they arrive
@@ -641,7 +799,7 @@ class GeminiHandler(BaseHTTPRequestHandler):
                 first_chunk = {"id": cid, "object": "chat.completion.chunk", "created": int(time.time()),
                                "model": model_name, "choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}]}
                 self.wfile.write(f"data: {json.dumps(first_chunk)}\n\n".encode())
-                for delta_text in gemini_stream_generate_iter(prompt, model_id, think_mode):
+                for delta_text in gemini_stream_generate_iter(prompt, model_id, think_mode, file_refs):
                     chunk = {"id": cid, "object": "chat.completion.chunk", "created": int(time.time()),
                              "model": model_name, "choices": [{"index": 0, "delta": {"content": delta_text}, "finish_reason": None}]}
                     self.wfile.write(f"data: {json.dumps(chunk, ensure_ascii=False)}\n\n".encode())
@@ -660,7 +818,7 @@ class GeminiHandler(BaseHTTPRequestHandler):
 
         # Non-streaming (or tool calling which needs full response)
         try:
-            text, tool_calls = self._call_gemini(prompt, model_id, think_mode, tools)
+            text, tool_calls = self._call_gemini(prompt, model_id, think_mode, tools, file_refs)
         except Exception as e:
             self.send_json({"error": {"message": f"upstream error: {e}"}}, 502)
             return
@@ -716,6 +874,8 @@ class GeminiHandler(BaseHTTPRequestHandler):
                     if item.get("type") == "function_call_output":
                         messages.append({"role": "tool", "tool_call_id": item.get("call_id", ""),
                                          "name": item.get("name", ""), "content": item.get("output", "")})
+                    elif item.get("type") in ("input_text", "input_image", "image"):
+                        messages.append({"role": "user", "content": [item]})
                     elif item.get("role") == "assistant" or (item.get("type") == "message" and item.get("role") == "assistant"):
                         cp = item.get("content", [])
                         text_acc, tc_list = "", []
@@ -734,22 +894,20 @@ class GeminiHandler(BaseHTTPRequestHandler):
                         messages.append(m)
                     else:
                         role = item.get("role", "user")
-                        content = item.get("content", "")
-                        if isinstance(content, list):
-                            content = " ".join(c.get("text", "") for c in content if c.get("type") in ("text", "input_text"))
-                        messages.append({"role": role, "content": content})
+                        messages.append({"role": role, "content": item.get("content", "")})
 
         if tools:
             tools = [{"type": "function", "function": {"name": t["name"], "description": t.get("description", ""), "parameters": t.get("parameters", {})}}
                      if t.get("type") == "function" and "function" not in t else t for t in tools]
 
-        prompt = messages_to_prompt(messages, tools)
+        prompt, images = messages_to_prompt(messages, tools)
         if not prompt.strip():
             self.send_json({"error": {"message": "empty input"}}, 400)
             return
 
         try:
-            text, tool_calls = self._call_gemini(prompt, model_id, think_mode, tools)
+            file_refs = upload_images(images)
+            text, tool_calls = self._call_gemini(prompt, model_id, think_mode, tools, file_refs)
         except Exception as e:
             self.send_json({"error": {"message": f"upstream error: {e}"}}, 502)
             return
@@ -829,29 +987,6 @@ class GeminiHandler(BaseHTTPRequestHandler):
             })
         self.send_json({"models": models})
 
-    def _google_contents_to_prompt(self, req: dict) -> str:
-        """Convert Google API contents format to prompt string."""
-        parts = []
-        sys_inst = req.get("systemInstruction")
-        if sys_inst:
-            sys_parts = sys_inst.get("parts", [])
-            sys_text = " ".join(p.get("text", "") for p in sys_parts if p.get("text"))
-            if sys_text:
-                parts.append(f"[System instruction]: {sys_text}")
-
-        for content in req.get("contents", []):
-            role = content.get("role", "user")
-            text_parts = []
-            for p in content.get("parts", []):
-                if p.get("text"):
-                    text_parts.append(p["text"])
-            text = " ".join(text_parts)
-            if role == "model":
-                parts.append(f"[Assistant]: {text}")
-            else:
-                parts.append(text)
-        return "\n\n".join(p for p in parts if p)
-
     def _handle_google_generate(self, body: bytes, stream: bool):
         """Handle Google native generateContent / streamGenerateContent."""
         req = json.loads(body)
@@ -865,13 +1000,14 @@ class GeminiHandler(BaseHTTPRequestHandler):
             self.send_json({"error": {"message": err}}, 400)
             return
 
-        prompt = self._google_contents_to_prompt(req)
+        prompt, images = google_contents_to_prompt(req)
         if not prompt.strip():
             self.send_json({"error": {"message": "empty content"}}, 400)
             return
 
         try:
-            text, _ = self._call_gemini(prompt, model_id, think_mode, None)
+            file_refs = upload_images(images)
+            text, _ = self._call_gemini(prompt, model_id, think_mode, None, file_refs)
         except Exception as e:
             self.send_json({"error": {"message": f"upstream error: {e}"}}, 502)
             return

--- a/gemini_web2api/multimodal.py
+++ b/gemini_web2api/multimodal.py
@@ -6,6 +6,7 @@ import urllib.parse
 import time
 import ssl
 import re
+from urllib.parse import urlparse
 
 from .config import CONFIG
 from .gemini import load_cookie, make_sapisidhash, _get_ssl_ctx, log
@@ -19,9 +20,19 @@ def _get_page_tokens() -> dict:
     cookie_str, sapisid = load_cookie()
     if cookie_str:
         headers["Cookie"] = cookie_str
+    if sapisid:
+        headers["Authorization"] = make_sapisidhash(sapisid)
     try:
         req = urllib.request.Request("https://gemini.google.com/app", headers=headers)
-        resp = urllib.request.urlopen(req, context=_get_ssl_ctx(), timeout=30)
+        proxy = CONFIG.get("proxy")
+        if proxy:
+            opener = urllib.request.build_opener(
+                urllib.request.ProxyHandler({"http": proxy, "https": proxy}),
+                urllib.request.HTTPSHandler(context=_get_ssl_ctx()),
+            )
+            resp = opener.open(req, timeout=30)
+        else:
+            resp = urllib.request.urlopen(req, context=_get_ssl_ctx(), timeout=30)
         html = resp.read().decode()
         tokens = {}
         for key, pattern in [
@@ -47,6 +58,31 @@ def _cached_page_tokens() -> dict:
         _page_tokens_cache["tokens"] = _get_page_tokens()
         _page_tokens_cache["ts"] = now
     return _page_tokens_cache["tokens"]
+
+
+def detect_image_mime(image_bytes: bytes, fallback: str = "image/png") -> str:
+    """Infer a common raster image MIME type from its file signature."""
+    if not isinstance(image_bytes, bytes):
+        return fallback
+    if image_bytes.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if image_bytes.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if image_bytes.startswith((b"GIF87a", b"GIF89a")):
+        return "image/gif"
+    if image_bytes.startswith(b"RIFF") and image_bytes[8:12] == b"WEBP":
+        return "image/webp"
+    if image_bytes.startswith(b"BM"):
+        return "image/bmp"
+    if image_bytes.startswith((b"II*\x00", b"MM\x00*")):
+        return "image/tiff"
+    if len(image_bytes) >= 12 and image_bytes[4:8] == b"ftyp":
+        brand = image_bytes[8:12]
+        if brand in (b"avif", b"avis"):
+            return "image/avif"
+        if brand in (b"heic", b"heix", b"hevc", b"hevx"):
+            return "image/heic"
+    return fallback
 
 
 def upload_image(image_bytes: bytes, filename: str = "image.png", mime_type: str = "image/png") -> str:
@@ -118,9 +154,21 @@ def upload_image(image_bytes: bytes, filename: str = "image.png", mime_type: str
 
 def fetch_image_bytes(url: str) -> bytes:
     """Fetch image from URL."""
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        log(f"Image fetch skipped for unsupported URL scheme: {parsed.scheme or 'none'}")
+        return b""
     try:
         req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
-        resp = urllib.request.urlopen(req, timeout=30)
+        proxy = CONFIG.get("proxy")
+        if proxy:
+            opener = urllib.request.build_opener(
+                urllib.request.ProxyHandler({"http": proxy, "https": proxy}),
+                urllib.request.HTTPSHandler(context=_get_ssl_ctx()),
+            )
+            resp = opener.open(req, timeout=30)
+        else:
+            resp = urllib.request.urlopen(req, context=_get_ssl_ctx(), timeout=30)
         return resp.read()
     except Exception as e:
         log(f"Image fetch failed: {e}")

--- a/gemini_web2api/server.py
+++ b/gemini_web2api/server.py
@@ -10,7 +10,7 @@ from .config import CONFIG
 from .models import MODELS, resolve_model
 from .gemini import generate, generate_stream, log
 from .tools import messages_to_prompt, parse_tool_calls, google_contents_to_prompt, parse_google_function_calls
-from .multimodal import upload_image, fetch_image_bytes
+from .multimodal import detect_image_mime, fetch_image_bytes, upload_image
 from . import __version__
 
 
@@ -26,17 +26,20 @@ def _upload_images(images: list) -> list:
         return None
     file_refs = []
     for item in images:
+        if not (isinstance(item, tuple) and len(item) == 2):
+            continue
+        data, mime = item
+        if isinstance(data, str):
+            data = fetch_image_bytes(data)
+            mime = mime or "image/png"
+        if not data:
+            raise RuntimeError("image fetch failed")
+        mime = detect_image_mime(data, mime or "image/png")
         try:
-            if isinstance(item, tuple) and len(item) == 2:
-                data, mime = item
-                if isinstance(data, str):
-                    data = fetch_image_bytes(data)
-                    mime = mime or "image/png"
-                if data:
-                    ref = upload_image(data, "image.png", mime or "image/png")
-                    file_refs.append(ref)
+            ref = upload_image(data, "image.png", mime or "image/png")
+            file_refs.append(ref)
         except Exception as e:
-            log(f"Image upload failed: {e}")
+            raise RuntimeError(f"image upload failed: {e}") from e
     return file_refs if file_refs else None
 
 
@@ -153,10 +156,10 @@ class GeminiHandler(BaseHTTPRequestHandler):
                 self._handle_chat(body)
             elif self.path == "/v1/responses":
                 self._handle_responses(body)
-            elif ":generateContent" in self.path:
-                self._handle_google_generate(body, stream=False)
             elif ":streamGenerateContent" in self.path:
                 self._handle_google_generate(body, stream=True)
+            elif ":generateContent" in self.path:
+                self._handle_google_generate(body, stream=False)
             else:
                 self.send_json({"error": "not found"}, 404)
         except (BrokenPipeError, ConnectionResetError):
@@ -190,6 +193,11 @@ class GeminiHandler(BaseHTTPRequestHandler):
 
         stream = req.get("stream", False)
         cid = f"chatcmpl-{uuid.uuid4().hex[:12]}"
+        try:
+            file_refs = _upload_images(images)
+        except RuntimeError as e:
+            self.send_json({"error": {"message": f"upstream error: {e}"}}, 502)
+            return
 
         if stream and (not tools or tool_choice == "none"):
             try:
@@ -207,7 +215,7 @@ class GeminiHandler(BaseHTTPRequestHandler):
                 }
                 self.wfile.write(f"data: {json.dumps(first_chunk)}\n\n".encode())
                 self.wfile.flush()
-                for delta in generate_stream(prompt, model_id, think_mode, _upload_images(images), extra_fields):
+                for delta in generate_stream(prompt, model_id, think_mode, file_refs, extra_fields):
                     chunk = {"id": cid, "object": "chat.completion.chunk", "created": int(time.time()),
                              "model": model_name, "choices": [{"index": 0, "delta": {"content": delta}, "finish_reason": None}]}
                     self.wfile.write(f"data: {json.dumps(chunk, ensure_ascii=False)}\n\n".encode())
@@ -219,10 +227,12 @@ class GeminiHandler(BaseHTTPRequestHandler):
                 self.wfile.flush()
             except (BrokenPipeError, ConnectionResetError):
                 pass
+            except Exception as e:
+                log(f"Stream error: {e}")
             return
 
         try:
-            text = generate(prompt, model_id, think_mode, _upload_images(images), extra_fields)
+            text = generate(prompt, model_id, think_mode, file_refs, extra_fields)
         except Exception as e:
             self.send_json({"error": {"message": f"upstream error: {e}"}}, 502)
             return
@@ -279,14 +289,18 @@ class GeminiHandler(BaseHTTPRequestHandler):
                     if item.get("type") == "function_call_output":
                         messages.append({"role": "tool", "tool_call_id": item.get("call_id", ""),
                                          "name": item.get("name", ""), "content": item.get("output", "")})
+                    elif item.get("type") in ("input_text", "input_image", "image"):
+                        messages.append({"role": "user", "content": [item]})
                     elif item.get("role") == "assistant" or (item.get("type") == "message" and item.get("role") == "assistant"):
                         cp = item.get("content", [])
                         text_acc, tc_list = "", []
                         if isinstance(cp, list):
                             for c in cp:
                                 if isinstance(c, dict):
-                                    if c.get("type") == "output_text": text_acc += c.get("text", "")
-                                    elif c.get("type") == "function_call": tc_list.append(c)
+                                    if c.get("type") == "output_text":
+                                        text_acc += c.get("text", "")
+                                    elif c.get("type") == "function_call":
+                                        tc_list.append(c)
                         elif isinstance(cp, str):
                             text_acc = cp
                         m = {"role": "assistant", "content": text_acc or None}
@@ -297,10 +311,7 @@ class GeminiHandler(BaseHTTPRequestHandler):
                         messages.append(m)
                     else:
                         role = item.get("role", "user")
-                        content = item.get("content", "")
-                        if isinstance(content, list):
-                            content = " ".join(c.get("text", "") for c in content if c.get("type") in ("text", "input_text"))
-                        messages.append({"role": role, "content": content})
+                        messages.append({"role": role, "content": item.get("content", "")})
 
         if tools:
             tools = [{"type": "function", "function": {"name": t["name"], "description": t.get("description", ""), "parameters": t.get("parameters", {})}}
@@ -313,7 +324,8 @@ class GeminiHandler(BaseHTTPRequestHandler):
             return
 
         try:
-            text = generate(prompt, model_id, think_mode, _upload_images(images), extra_fields)
+            file_refs = _upload_images(images)
+            text = generate(prompt, model_id, think_mode, file_refs, extra_fields)
         except Exception as e:
             self.send_json({"error": {"message": f"upstream error: {e}"}}, 502)
             return
@@ -495,7 +507,11 @@ class GeminiHandler(BaseHTTPRequestHandler):
             self.send_json({"error": {"message": "empty content"}}, 400)
             return
 
-        file_refs = _upload_images(images)
+        try:
+            file_refs = _upload_images(images)
+        except RuntimeError as e:
+            self.send_json({"error": {"message": f"upstream error: {e}"}}, 502)
+            return
         log(f"Google API: model={model_name} stream={stream} tools={has_tools} prompt_len={len(prompt)}")
 
         if stream and not has_tools:
@@ -525,6 +541,8 @@ class GeminiHandler(BaseHTTPRequestHandler):
                 self.wfile.flush()
             except (BrokenPipeError, ConnectionResetError):
                 pass
+            except Exception as e:
+                log(f"Google stream error: {e}")
             return
 
         try:

--- a/gemini_web2api/tools.py
+++ b/gemini_web2api/tools.py
@@ -3,7 +3,9 @@ import json
 import re
 import uuid
 import base64
+import binascii
 import io
+from urllib.parse import unquote_to_bytes
 
 MAX_IMAGE_B64_SIZE = 50000  # ~37KB raw image
 
@@ -51,6 +53,54 @@ def _build_tool_choice_instruction(tool_choice, tool_defs: list) -> str:
     return ""
 
 
+def _decode_data_url(url: str):
+    match = re.match(r"^data:([^;,]+)?(;base64)?,(.*)$", url, re.DOTALL)
+    if not match:
+        return None
+    mime = match.group(1) or "image/png"
+    is_base64 = bool(match.group(2))
+    data = match.group(3)
+    try:
+        if is_base64:
+            return base64.b64decode(data, validate=True), mime
+        return unquote_to_bytes(data), mime
+    except (ValueError, TypeError, binascii.Error):
+        return None
+
+
+def _image_from_url(url: str, mime: str = None):
+    if not isinstance(url, str) or not url:
+        return None
+    if url.startswith("data:"):
+        return _decode_data_url(url)
+    return url, mime or "image/png"
+
+
+def _image_from_part(part: dict):
+    part_type = part.get("type")
+    if part_type == "image_url":
+        image_url = part.get("image_url", {})
+        if isinstance(image_url, dict):
+            return _image_from_url(image_url.get("url"), image_url.get("mime_type"))
+        return _image_from_url(image_url)
+    if part_type in ("input_image", "image"):
+        image_url = part.get("image_url") or part.get("url")
+        if isinstance(image_url, dict):
+            return _image_from_url(image_url.get("url"), image_url.get("mime_type"))
+        if image_url:
+            return _image_from_url(image_url, part.get("mime_type"))
+        image_data = part.get("data") or part.get("base64")
+        if isinstance(image_data, str):
+            mime = part.get("mime_type") or part.get("media_type") or "image/png"
+            if image_data.startswith("data:"):
+                return _decode_data_url(image_data)
+            try:
+                return base64.b64decode(image_data, validate=True), mime
+            except (ValueError, TypeError, binascii.Error):
+                return None
+    return None
+
+
 def messages_to_prompt(messages: list, tools: list = None, tool_choice=None) -> tuple:
     """Convert OpenAI messages to (prompt_str, images_list).
 
@@ -88,10 +138,11 @@ def messages_to_prompt(messages: list, tools: list = None, tool_choice=None) -> 
             for c in content:
                 if c.get("type") in ("text", "input_text"):
                     text_parts.append(c.get("text", ""))
-                elif c.get("type") == "image_url":
-                    text_parts.append("[Note: Image input not supported in this API. Please describe the image in text.]")
-                elif c.get("type") == "image":
-                    text_parts.append("[Note: Image input not supported in this API. Please describe the image in text.]")
+                else:
+                    image = _image_from_part(c)
+                    if image:
+                        images.append(image)
+                        text_parts.append("[Image attached]")
             content = " ".join(text_parts)
 
         if role == "system":
@@ -226,8 +277,14 @@ def google_contents_to_prompt(req: dict) -> tuple:
                 msg_parts.append(p["text"])
             elif p.get("inlineData"):
                 data = p["inlineData"]
-                mime = data.get("mimeType", "image/png")
-                images.append((base64.b64decode(data["data"]), mime))
+                try:
+                    images.append((
+                        base64.b64decode(data["data"], validate=True),
+                        data.get("mimeType", "image/png"),
+                    ))
+                    msg_parts.append("[Image attached]")
+                except (KeyError, ValueError, TypeError, binascii.Error):
+                    pass
             elif p.get("functionCall"):
                 fc = p["functionCall"]
                 msg_parts.append(

--- a/tests/test_modular_sync.py
+++ b/tests/test_modular_sync.py
@@ -1,4 +1,5 @@
 import http.client
+import base64
 import json
 import threading
 import unittest
@@ -8,6 +9,7 @@ from urllib.parse import parse_qs
 from gemini_web2api.config import CONFIG, DEFAULT_CONFIG
 from gemini_web2api.gemini import _build_payload
 from gemini_web2api.server import GeminiHandler, ThreadedServer
+from gemini_web2api.tools import google_contents_to_prompt, messages_to_prompt
 
 
 def _decode_payload(payload):
@@ -59,6 +61,82 @@ class PayloadPersistenceTests(unittest.TestCase):
         self.assertEqual(inner[41], [1])
         self.assertEqual(inner[45], 1)
 
+    def test_payload_includes_uploaded_image_refs(self):
+        inner = _decode_payload(_build_payload("describe", 1, 4, ["/uploaded/image-ref"]))
+
+        self.assertEqual(inner[0][0], "describe")
+        self.assertEqual(inner[0][3], [[None, None, "/uploaded/image-ref"]])
+
+
+class MessageParsingTests(unittest.TestCase):
+    def test_messages_to_prompt_extracts_openai_image_url_data_url(self):
+        image_data = base64.b64encode(b"fake png").decode()
+
+        prompt, images = messages_to_prompt([{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Describe"},
+                {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{image_data}"}},
+            ],
+        }])
+
+        self.assertEqual(prompt, "Describe [Image attached]")
+        self.assertEqual(images, [(b"fake png", "image/png")])
+
+    def test_messages_to_prompt_extracts_responses_input_image_url(self):
+        prompt, images = messages_to_prompt([{
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "Describe"},
+                {"type": "input_image", "image_url": "https://example.com/image.png"},
+            ],
+        }])
+
+        self.assertEqual(prompt, "Describe [Image attached]")
+        self.assertEqual(images, [("https://example.com/image.png", "image/png")])
+
+    def test_messages_to_prompt_ignores_malformed_image_data_url(self):
+        prompt, images = messages_to_prompt([{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Describe"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,%%%"}},
+            ],
+        }])
+
+        self.assertEqual(prompt, "Describe")
+        self.assertEqual(images, [])
+
+    def test_google_contents_to_prompt_extracts_inline_image_data(self):
+        image_data = base64.b64encode(b"fake png").decode()
+
+        prompt, images = google_contents_to_prompt({
+            "contents": [{
+                "role": "user",
+                "parts": [
+                    {"text": "Describe"},
+                    {"inlineData": {"mimeType": "image/png", "data": image_data}},
+                ],
+            }],
+        })
+
+        self.assertEqual(prompt, "Describe\n[Image attached]")
+        self.assertEqual(images, [(b"fake png", "image/png")])
+
+    def test_google_contents_to_prompt_ignores_malformed_inline_image_data(self):
+        prompt, images = google_contents_to_prompt({
+            "contents": [{
+                "role": "user",
+                "parts": [
+                    {"text": "Describe"},
+                    {"inlineData": {"mimeType": "image/png", "data": "%%%"}},
+                ],
+            }],
+        })
+
+        self.assertEqual(prompt, "Describe")
+        self.assertEqual(images, [])
+
 
 class StreamingEndpointTests(unittest.TestCase):
     @classmethod
@@ -97,6 +175,21 @@ class StreamingEndpointTests(unittest.TestCase):
         connection.close()
         return response.status, headers, body
 
+    def post_chunked_json(self, path, payload):
+        connection = http.client.HTTPConnection("127.0.0.1", self.port, timeout=5)
+        connection.request(
+            "POST",
+            path,
+            body=json.dumps(payload).encode(),
+            headers={"Content-Type": "application/json"},
+            encode_chunked=True,
+        )
+        response = connection.getresponse()
+        body = response.read().decode()
+        headers = dict(response.getheaders())
+        connection.close()
+        return response.status, headers, body
+
     @mock.patch("gemini_web2api.server.generate_stream")
     def test_chat_stream_starts_with_assistant_role(self, generate_stream):
         generate_stream.return_value = iter(["hel", "lo"])
@@ -121,6 +214,139 @@ class StreamingEndpointTests(unittest.TestCase):
         self.assertEqual(chunks[1]["choices"][0]["delta"], {"content": "hel"})
         self.assertEqual(chunks[2]["choices"][0]["delta"], {"content": "lo"})
         self.assertTrue(body.endswith("data: [DONE]\n\n"))
+
+    @mock.patch("gemini_web2api.server.generate", return_value="chunked ok")
+    def test_chat_accepts_chunked_body(self, _generate):
+        status, _, body = self.post_chunked_json(
+            "/v1/chat/completions",
+            {
+                "model": "gemini-3.6-flash",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(json.loads(body)["choices"][0]["message"]["content"], "chunked ok")
+
+    @mock.patch("gemini_web2api.server.upload_image", return_value="/uploaded/image-ref")
+    @mock.patch("gemini_web2api.server.generate", return_value="looks good")
+    def test_chat_accepts_openai_image_url_data_url(self, generate, upload_image):
+        image_data = base64.b64encode(b"fake png").decode()
+
+        status, _, body = self.post_json(
+            "/v1/chat/completions",
+            {
+                "model": "gemini-3.6-flash",
+                "messages": [{
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Describe this image"},
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": f"data:image/png;base64,{image_data}"
+                            },
+                        },
+                    ],
+                }],
+            },
+        )
+
+        self.assertEqual(status, 200)
+        upload_image.assert_called_once_with(b"fake png", "image.png", "image/png")
+        self.assertEqual(generate.call_args.args[3], ["/uploaded/image-ref"])
+        self.assertIn("[Image attached]", generate.call_args.args[0])
+        self.assertEqual(json.loads(body)["choices"][0]["message"]["content"], "looks good")
+
+    @mock.patch("gemini_web2api.server.fetch_image_bytes", return_value=b"\xff\xd8\xffremote jpeg")
+    @mock.patch("gemini_web2api.server.upload_image", return_value="/uploaded/remote-ref")
+    @mock.patch("gemini_web2api.server.generate", return_value="remote ok")
+    def test_responses_accepts_input_image_url(self, generate, upload_image, fetch_image_bytes):
+        status, _, _ = self.post_json(
+            "/v1/responses",
+            {
+                "model": "gemini-3.6-flash",
+                "input": [{
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "What is shown?"},
+                        {
+                            "type": "input_image",
+                            "image_url": "https://example.com/image.jpg",
+                        },
+                    ],
+                }],
+            },
+        )
+
+        self.assertEqual(status, 200)
+        fetch_image_bytes.assert_called_once_with("https://example.com/image.jpg")
+        upload_image.assert_called_once_with(b"\xff\xd8\xffremote jpeg", "image.png", "image/jpeg")
+        self.assertEqual(generate.call_args.args[3], ["/uploaded/remote-ref"])
+        self.assertIn("[Image attached]", generate.call_args.args[0])
+
+    @mock.patch("gemini_web2api.server.upload_image", return_value="/uploaded/image-ref")
+    @mock.patch("gemini_web2api.server.generate", return_value="top-level image ok")
+    def test_responses_accepts_top_level_input_image(self, generate, upload_image):
+        image_data = base64.b64encode(b"fake png").decode()
+
+        status, _, _ = self.post_json(
+            "/v1/responses",
+            {
+                "model": "gemini-3.6-flash",
+                "input": [
+                    {"type": "input_text", "text": "What is shown?"},
+                    {
+                        "type": "input_image",
+                        "image_url": f"data:image/png;base64,{image_data}",
+                    },
+                ],
+            },
+        )
+
+        self.assertEqual(status, 200)
+        upload_image.assert_called_once_with(b"fake png", "image.png", "image/png")
+        self.assertEqual(generate.call_args.args[3], ["/uploaded/image-ref"])
+        self.assertIn("What is shown?", generate.call_args.args[0])
+        self.assertIn("[Image attached]", generate.call_args.args[0])
+
+    @mock.patch("gemini_web2api.server.upload_image", side_effect=RuntimeError("upload denied"))
+    def test_google_image_upload_failure_returns_502(self, _upload_image):
+        image_data = base64.b64encode(b"fake png").decode()
+
+        status, _, body = self.post_json(
+            "/v1beta/models/gemini-3.6-flash:generateContent",
+            {
+                "contents": [{
+                    "role": "user",
+                    "parts": [{
+                        "inlineData": {
+                            "mimeType": "image/png",
+                            "data": image_data,
+                        },
+                    }],
+                }],
+            },
+        )
+
+        self.assertEqual(status, 502)
+        self.assertIn("image upload failed: upload denied", json.loads(body)["error"]["message"])
+
+    @mock.patch("gemini_web2api.server.generate_stream", return_value=iter(["streamed"]))
+    def test_google_stream_generate_content_uses_sse(self, _generate_stream):
+        status, headers, body = self.post_json(
+            "/v1beta/models/gemini-3.6-flash:streamGenerateContent",
+            {
+                "contents": [{
+                    "role": "user",
+                    "parts": [{"text": "Stream this"}],
+                }],
+            },
+        )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(headers["Content-Type"], "text/event-stream")
+        self.assertIn('"text": "streamed"', body)
 
     @mock.patch("gemini_web2api.server.generate", return_value="hello")
     def test_responses_text_stream_has_complete_event_sequence(self, _generate):


### PR DESCRIPTION
## Summary
- Add OpenAI-style multimodal image input parsing for Chat Completions and Responses API payloads.
- Support `content` arrays with `image_url`, `input_image`, `image`, `data:` URLs, raw base64 payloads, and Google `inlineData` image parts.
- Upload parsed image inputs through Gemini Web file references, including MIME signature detection and proxy-aware remote image fetching.
- Improve compatibility around streaming, chunked request bodies, Google `generateContent` routing, Responses API input handling, and upload failure responses.
- Update English and Chinese documentation for image input usage and limitations.

## Tests
- `pytest tests/test_modular_sync.py -q` — 18 passed

## Commit Split
- `feat: add multimodal image parsing helpers`
- `feat: wire multimodal inputs through API handlers`
- `test: cover multimodal and compatibility behavior`
- `docs: document image input support`
