### PR TITLE
feat(models): 新增 gemini-3.7-flash 并调整 3.6 版本描述

### DIFF
--- a/gemini_web2api.py
+++ b/gemini_web2api.py
@@ -69,9 +69,13 @@ CONFIG = dict(DEFAULT_CONFIG)
 #   1=FAST, 2=THINKING, 3=PRO, 4=AUTO, 5=FAST_DYNAMIC_THINKING, 6=FLASH_LITE
 
 MODELS = {
+    "gemini-3.7-flash": {
+        "mode": 1, "think": 4,
+        "desc": "Latest all-around model (Gemini 3.7 Flash)",
+    },
     "gemini-3.6-flash": {
         "mode": 1, "think": 4,
-        "desc": "Latest all-around model (Gemini 3.6 Flash)",
+        "desc": "All-around model (Gemini 3.6 Flash)",
     },
     "gemini-3.5-flash": {
         "mode": 1, "think": 4,

--- a/gemini_web2api/models.py
+++ b/gemini_web2api/models.py
@@ -4,9 +4,13 @@
 #   1=FAST, 2=THINKING, 3=PRO, 4=AUTO, 5=FAST_DYNAMIC_THINKING, 6=FLASH_LITE
 
 MODELS = {
+    "gemini-3.7-flash": {
+        "mode": 1, "think": 4,
+        "desc": "Latest all-around model (Gemini 3.7 Flash)",
+    },
     "gemini-3.6-flash": {
         "mode": 1, "think": 4,
-        "desc": "Latest all-around model (Gemini 3.6 Flash)",
+        "desc": "All-around model (Gemini 3.6 Flash)",
     },
     "gemini-3.5-flash": {
         "mode": 1, "think": 4,


### PR DESCRIPTION
同步更新 gemini_web2api.py 和 gemini_web2api/models.py 中的 MODELS 字典，添加 gemini-3.7-flash 模型条目，并将
gemini-3.6-flash 的描述标记从 "Latest" 更新为普通 "All-around"， 以区分新旧版本。